### PR TITLE
Fixes start muted extension.

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriConferenceIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriConferenceIQ.java
@@ -1064,7 +1064,8 @@ public class ColibriConferenceIQ
         {
             // direction
             String direction = getDirection();
-            if ((direction != null) && (direction != SENDRECV))
+            if (direction != null
+                && !direction.equals(SENDRECV))
             {
                 xml.attribute(DIRECTION_ATTR_NAME, direction);
             }

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/StartMutedPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/StartMutedPacketExtension.java
@@ -25,7 +25,6 @@ import org.jitsi.xmpp.extensions.*;
 public class StartMutedPacketExtension
     extends AbstractPacketExtension
 {
-
     /**
      * Name space of start muted packet extension.
      */
@@ -78,7 +77,7 @@ public class StartMutedPacketExtension
      */
     public boolean getAudioMuted()
     {
-        return (Boolean)getAttribute(AUDIO_ATTRIBUTE_NAME);
+        return Boolean.valueOf(getAttributeAsString(AUDIO_ATTRIBUTE_NAME));
     }
 
     /**
@@ -87,7 +86,6 @@ public class StartMutedPacketExtension
      */
     public boolean getVideoMuted()
     {
-        return (Boolean)getAttribute(VIDEO_ATTRIBUTE_NAME);
+        return Boolean.valueOf(getAttributeAsString(VIDEO_ATTRIBUTE_NAME));
     }
-
 }


### PR DESCRIPTION
Fixes exception seen in tests:
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Boolean
	at org.jitsi.xmpp.extensions.jitsimeet.StartMutedPacketExtension.getAudioMuted(StartMutedPacketExtension.java:81)