### PR TITLE
fix(ColibriBuilder): do not log error if no endpoint id for a bundle

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriBuilder.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriBuilder.java
@@ -470,10 +470,6 @@ public class ColibriBuilder
 
             request.addChannelBundle(bundle);
         }
-        else if (useBundle && endpointId == null)
-        {
-            logger.error("Bundle requested, but no endpointId provided.");
-        }
 
         if (endpointId != null)
         {


### PR DESCRIPTION
Do not log the error if not endpoint ID for a bundle, because it's allowed for the Octo case.