### PR TITLE
Add 'shouldRetry' field to JibriIq

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
@@ -442,7 +442,7 @@ public class JibriIq
 
     public void setShouldRetry(Boolean shouldRetry) { this.shouldRetry = shouldRetry; }
 
-    public Boolean shouldRetry() { return this.shouldRetry; }
+    public Boolean getShouldRetry() { return this.shouldRetry; }
 
     public static JibriIq createResult(JibriIq request, String sessionId)
     {

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
@@ -82,6 +82,13 @@ public class JibriIq
     static final String FAILURE_REASON_ATTR_NAME = "failure_reason";
 
     /**
+     * The name of the XML attribute which stores whether or not
+     * Jicofo should retry this request.  Used when the response
+     * indicates an error.
+     */
+    static final String SHOULD_RETRY_ATTR_NAME = "should_retry";
+
+    /**
      * The name of XML attribute which stores the stream id.
      */
     static final String STREAM_ID_ATTR_NAME = "streamid";
@@ -152,6 +159,13 @@ public class JibriIq
      * to describe an 'unclean' to transition to off (e.g. 'error')
      */
     private FailureReason failureReason = null;
+
+    /**
+     * In the event of an error, this field denotes whether or not
+     * Jicofo should retry the request (for which this error response
+     * corresponds) with another Jibri.
+     */
+    private Boolean shouldRetry = null;
 
     /**
      * The ID of the stream which will be used to record the conference. The
@@ -315,6 +329,12 @@ public class JibriIq
     }
 
     /**
+     * Whether or not this IQ represents a failure from Jibri
+     * @return true if it represents failure, false otherwise
+     */
+    public boolean isFailure() { return this.failureReason != null; }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -342,6 +362,12 @@ public class JibriIq
         xml.optAttribute(SIP_ADDRESS_ATTR_NAME, sipAddress);
         xml.optAttribute(SESSION_ID_ATTR_NAME, sessionId);
         xml.optAttribute(FAILURE_REASON_ATTR_NAME, failureReason);
+        if (failureReason != null && failureReason != FailureReason.UNDEFINED) {
+            if (shouldRetry == null) {
+                throw new RuntimeException("shouldRetry field must be filled out when a failure reason is set");
+            }
+            xml.attribute(SHOULD_RETRY_ATTR_NAME, shouldRetry);
+        }
         xml.optAttribute(APP_DATA_ATTR_NAME, appData);
 
         xml.setEmptyElement();
@@ -413,6 +439,10 @@ public class JibriIq
     {
         return this.failureReason;
     }
+
+    public void setShouldRetry(Boolean shouldRetry) { this.shouldRetry = shouldRetry; }
+
+    public Boolean shouldRetry() { return this.shouldRetry; }
 
     public static JibriIq createResult(JibriIq request, String sessionId)
     {

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
@@ -364,7 +364,8 @@ public class JibriIq
         xml.optAttribute(FAILURE_REASON_ATTR_NAME, failureReason);
         if (failureReason != null && failureReason != FailureReason.UNDEFINED) {
             if (shouldRetry == null) {
-                throw new RuntimeException("shouldRetry field must be filled out when a failure reason is set");
+                throw new RuntimeException("shouldRetry field must be filled " +
+                    "out when a failure reason is set");
             }
             xml.attribute(SHOULD_RETRY_ATTR_NAME, shouldRetry);
         }

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
@@ -101,6 +101,16 @@ public class JibriIqProvider
             {
                 iq.setFailureReason(JibriIq.FailureReason.parse(failureStr));
             }
+            String shouldRetryStr
+                = parser.getAttributeValue("", JibriIq.SHOULD_RETRY_ATTR_NAME);
+            if (StringUtils.isNotEmpty(shouldRetryStr))
+            {
+                iq.setShouldRetry(Boolean.valueOf(shouldRetryStr));
+            }
+            else if (iq.getFailureReason() != null && iq.getFailureReason() != JibriIq.FailureReason.UNDEFINED)
+            {
+                throw new RuntimeException("shouldRetry must be set if a failure reason is given");
+            }
 
             String displayName
                 = parser.getAttributeValue("", JibriIq.DISPLAY_NAME_ATTR_NAME);

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
@@ -102,14 +102,17 @@ public class JibriIqProvider
                 iq.setFailureReason(JibriIq.FailureReason.parse(failureStr));
             }
             String shouldRetryStr
-                = parser.getAttributeValue("", JibriIq.SHOULD_RETRY_ATTR_NAME);
+                = parser.getAttributeValue(
+                    "", JibriIq.SHOULD_RETRY_ATTR_NAME);
             if (StringUtils.isNotEmpty(shouldRetryStr))
             {
                 iq.setShouldRetry(Boolean.valueOf(shouldRetryStr));
             }
-            else if (iq.getFailureReason() != null && iq.getFailureReason() != JibriIq.FailureReason.UNDEFINED)
+            else if (iq.getFailureReason() != null
+                && iq.getFailureReason() != JibriIq.FailureReason.UNDEFINED)
             {
-                throw new RuntimeException("shouldRetry must be set if a failure reason is given");
+                throw new RuntimeException("shouldRetry must be set if a " +
+                    "failure reason is given");
             }
 
             String displayName

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/RecordingStatus.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/RecordingStatus.java
@@ -120,6 +120,7 @@ public class RecordingStatus
      */
     public JibriIq.FailureReason getFailureReason()
     {
+        //TODO: do we need to put shouldRetry here as well?
         String failureReasonStr = getAttributeAsString(JibriIq.FAILURE_REASON_ATTR_NAME);
         return JibriIq.FailureReason.parse(failureReasonStr);
     }

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/RecordingStatus.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/RecordingStatus.java
@@ -120,7 +120,6 @@ public class RecordingStatus
      */
     public JibriIq.FailureReason getFailureReason()
     {
-        //TODO: do we need to put shouldRetry here as well?
         String failureReasonStr = getAttributeAsString(JibriIq.FAILURE_REASON_ATTR_NAME);
         return JibriIq.FailureReason.parse(failureReasonStr);
     }


### PR DESCRIPTION
This allows Jibri to tell Jicofo whether or not the error encountered had to do with the request itself (i.e. any Jibri would fail because of it) or some other type of error and the request should be retried.  Specifically, this lets us tell Jicofo not to retry in the case of a bad stream key.