### PR TITLE
relax validation on the presence of the 'shouldRetry' field when there

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
@@ -362,13 +362,7 @@ public class JibriIq
         xml.optAttribute(SIP_ADDRESS_ATTR_NAME, sipAddress);
         xml.optAttribute(SESSION_ID_ATTR_NAME, sessionId);
         xml.optAttribute(FAILURE_REASON_ATTR_NAME, failureReason);
-        if (failureReason != null && failureReason != FailureReason.UNDEFINED) {
-            if (shouldRetry == null) {
-                throw new RuntimeException("shouldRetry field must be filled " +
-                    "out when a failure reason is set");
-            }
-            xml.attribute(SHOULD_RETRY_ATTR_NAME, shouldRetry);
-        }
+        xml.attribute(SHOULD_RETRY_ATTR_NAME, shouldRetry);
         xml.optAttribute(APP_DATA_ATTR_NAME, appData);
 
         xml.setEmptyElement();

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
@@ -108,12 +108,6 @@ public class JibriIqProvider
             {
                 iq.setShouldRetry(Boolean.valueOf(shouldRetryStr));
             }
-            else if (iq.getFailureReason() != null
-                && iq.getFailureReason() != JibriIq.FailureReason.UNDEFINED)
-            {
-                throw new RuntimeException("shouldRetry must be set if a " +
-                    "failure reason is given");
-            }
 
             String displayName
                 = parser.getAttributeValue("", JibriIq.DISPLAY_NAME_ATTR_NAME);


### PR DESCRIPTION
is a jibri failure

since we may have old jibris running alongside new ones, we can't
require this as older code won't have it present.  once old jibris are
out of use, we can revert this commit to bring them back.