### PR TITLE
update smack to 4.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <packaging>bundle</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <smack.version>4.2.4-47d17fc</smack.version>
+    <smack.version>4.3.4</smack.version>
   </properties>
 
   <name>jitsi-xmpp-extensions</name>

--- a/src/main/java/org/jitsi/xmpp/extensions/AbstractPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/AbstractPacketExtension.java
@@ -154,7 +154,7 @@ public abstract class AbstractPacketExtension
      *
      * @return an XML representation of this extension.
      */
-    public String toXML()
+    public String toXML(String s)
     {
         XmlStringBuilder xml = new XmlStringBuilder();
 

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriConferenceIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriConferenceIQ.java
@@ -145,9 +145,9 @@ public class ColibriConferenceIQ
      */
     public static IQ createGracefulShutdownErrorResponse(final IQ request)
     {
-        final XMPPError error = XMPPError.getBuilder()
-            .setCondition(XMPPError.Condition.service_unavailable)
-            .setType(XMPPError.Type.CANCEL)
+        final StanzaError error = StanzaError.getBuilder()
+            .setCondition(StanzaError.Condition.service_unavailable)
+            .setType(StanzaError.Type.CANCEL)
             .addExtension(new GracefulShutdown())
             .build();
 
@@ -313,7 +313,7 @@ public class ColibriConferenceIQ
             if (rtcpTerminationStrategy != null)
                 rtcpTerminationStrategy.toXML(xml);
             if (gracefulShutdown)
-                xml.append(new GracefulShutdown().toXML());
+                xml.append(new GracefulShutdown().toXML(null));
         }
 
         return xml;
@@ -1128,17 +1128,17 @@ public class ColibriConferenceIQ
             int[] ssrcs = getSSRCs();
 
             for (PayloadTypePacketExtension payloadType : payloadTypes)
-                xml.append(payloadType.toXML());
+                xml.append(payloadType.toXML(null));
 
             for (RTPHdrExtPacketExtension ext : rtpHdrExtPacketExtensions)
-                xml.append(ext.toXML());
+                xml.append(ext.toXML(null));
 
             for (SourcePacketExtension source : sources)
-                xml.append(source.toXML());
+                xml.append(source.toXML(null));
 
             if (sourceGroups != null && sourceGroups.size() != 0)
                 for (SourceGroupPacketExtension sourceGroup : sourceGroups)
-                    xml.append(sourceGroup.toXML());
+                    xml.append(sourceGroup.toXML(null));
 
             for (int i = 0; i < ssrcs.length; i++)
             {
@@ -1589,7 +1589,7 @@ public class ColibriConferenceIQ
             if (transport != null)
             {
                 xml.rightAngleBracket();
-                xml.append(transport.toXML());
+                xml.append(transport.toXML(null));
                 xml.closeElement(ELEMENT_NAME);
             }
             else
@@ -1931,7 +1931,7 @@ public class ColibriConferenceIQ
 
                 if (hasTransport)
                 {
-                    xml.append(transport.toXML());
+                    xml.append(transport.toXML(null));
                 }
 
                 xml.closeElement(elementName);
@@ -2547,6 +2547,7 @@ public class ColibriConferenceIQ
         {
             super(ColibriConferenceIQ.NAMESPACE, ELEMENT_NAME);
         }
+
     }
 
     public static class RTCPTerminationStrategy

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriStatsExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriStatsExtension.java
@@ -662,7 +662,7 @@ public class ColibriStatsExtension
         }
 
         @Override
-        public String toXML()
+        public String toXML(String s)
         {
             String name = getName();
             Object value = getValue();

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriStatsIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriStatsIQ.java
@@ -51,7 +51,7 @@ public class ColibriStatsIQ
     protected IQ.IQChildElementXmlStringBuilder getIQChildElementBuilder(IQ.IQChildElementXmlStringBuilder buf)
     {
         buf.rightAngleBracket();
-        buf.append(backEnd.toXML());
+        buf.append(backEnd.toXML(null));
         return buf;
     }
 

--- a/src/main/java/org/jitsi/xmpp/extensions/inputevt/InputEvtIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/inputevt/InputEvtIQ.java
@@ -92,7 +92,7 @@ public class InputEvtIQ extends IQ
             // FIXME use extensions list of IQ
             for(RemoteControlExtension p : remoteControls)
             {
-                bldr.append(p.toXML());
+                bldr.append(p.toXML(null));
             }
         }
         else

--- a/src/main/java/org/jitsi/xmpp/extensions/inputevt/RemoteControlExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/inputevt/RemoteControlExtension.java
@@ -120,7 +120,7 @@ public class RemoteControlExtension
      *
      * @return XML representation of the item
      */
-    public String toXML()
+    public String toXML(String s)
     {
         String ret = null;
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/RecordingStatus.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/RecordingStatus.java
@@ -140,7 +140,7 @@ public class RecordingStatus
      * Returns <tt>XMPPError</tt> associated with current
      * {@link RecordingStatus}.
      */
-    public XMPPError getError()
+    public StanzaError getError()
     {
         XMPPErrorPE errorPe = getErrorPE();
         return errorPe != null ? errorPe.getError() : null;
@@ -161,10 +161,10 @@ public class RecordingStatus
 
     /**
      * Sets <tt>XMPPError</tt> on this <tt>RecordingStatus</tt>.
-     * @param error <tt>XMPPError</tt> to add error details to this
+     * @param error <tt>StanzaError</tt> to add error details to this
      * <tt>RecordingStatus</tt> instance or <tt>null</tt> to have it removed.
      */
-    public void setError(XMPPError error)
+    public void setError(StanzaError error)
     {
         if (error != null)
         {
@@ -206,4 +206,5 @@ public class RecordingStatus
     {
         return initiator;
     }
+
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/XMPPErrorPE.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/XMPPErrorPE.java
@@ -20,31 +20,31 @@ import org.jivesoftware.smack.packet.*;
 import java.util.*;
 
 /**
- * Wraps Smack's <tt>XMPPError</tt> into <tt>ExtensionElement</tt>, so that it
+ * Wraps Smack's <tt>StanzaError</tt> into <tt>ExtensionElement</tt>, so that it
  * can be easily inserted into {@link RecordingStatus}.
  */
 public class XMPPErrorPE
     implements ExtensionElement
 {
     /**
-     * <tt>XMPPError</tt> wrapped into this <tt>XMPPErrorPE</tt>.
+     * <tt>StanzaError</tt> wrapped into this <tt>XMPPErrorPE</tt>.
      */
-    private XMPPError error;
+    private StanzaError error;
 
     /**
      * Creates new instance of <tt>XMPPErrorPE</tt>.
-     * @param xmppError the instance of <tt>XMPPError</tt> that will be wrapped
+     * @param xmppError the instance of <tt>StanzaError</tt> that will be wrapped
      * by the newly created <tt>XMPPErrorPE</tt>.
      */
-    public XMPPErrorPE(XMPPError xmppError)
+    public XMPPErrorPE(StanzaError xmppError)
     {
         setError(xmppError);
     }
 
     /**
-     * Returns the underlying instance of <tt>XMPPError</tt>.
+     * Returns the underlying instance of <tt>StanzaError</tt>.
      */
-    public XMPPError getError()
+    public StanzaError getError()
     {
         return error;
     }
@@ -52,10 +52,10 @@ public class XMPPErrorPE
     /**
      * Sets new instance of <tt>XMPPError</tt> to be wrapped by this
      * <tt>XMPPErrorPE</tt>.
-     * @param error <tt>XMPPError</tt> that will be wrapped by this
+     * @param error <tt>StanzaError</tt> that will be wrapped by this
      * <TT>XMPPErrorPE</TT>.
      */
-    public void setError(XMPPError error)
+    public void setError(StanzaError error)
     {
         Objects.requireNonNull(error, "error");
 
@@ -84,8 +84,8 @@ public class XMPPErrorPE
      * {@inheritDoc}
      */
     @Override
-    public String toXML()
+    public String toXML(String s)
     {
-        return error.toXML().toString();
+        return error.toXML(null).toString();
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/JingleIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/JingleIQ.java
@@ -155,18 +155,18 @@ public class JingleIQ extends IQ
             //content
             for(ContentPacketExtension cpe : contentList)
             {
-                bldr.append(cpe.toXML());
+                bldr.append(cpe.toXML(null));
             }
 
             //reason
             if (reason != null)
-                bldr.append(reason.toXML());
+                bldr.append(reason.toXML(null));
 
             //session-info
             //XXX: this is RTP specific so we should probably handle it in a
             //subclass
             if (sessionInfo != null)
-                bldr.append(sessionInfo.toXML());
+                bldr.append(sessionInfo.toXML(null));
         }
 
         return bldr;

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/ReasonPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/ReasonPacketExtension.java
@@ -172,7 +172,7 @@ public class ReasonPacketExtension
      *
      * @return the packet extension as XML.
      */
-    public String toXML()
+    public String toXML(String s)
     {
         XmlStringBuilder xml = new XmlStringBuilder();
         xml.openElement(getElementName());
@@ -188,7 +188,7 @@ public class ReasonPacketExtension
         //add the extra element if it has been specified.
         if(getOtherExtension() != null)
         {
-            xml.append(getOtherExtension().toXML());
+            xml.append(getOtherExtension().toXML(null));
         }
 
         xml.closeElement(getElementName());

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/SctpMapExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/SctpMapExtension.java
@@ -92,7 +92,7 @@ public class SctpMapExtension
      * {@inheritDoc}
      */
     @Override
-    public String toXML()
+    public String toXML(String s)
     {
         XmlStringBuilder xml = new XmlStringBuilder();
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/RelayPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/RelayPacketExtension.java
@@ -77,7 +77,7 @@ public class RelayPacketExtension
      * @return XML string representation
      */
     @Override
-    public String toXML()
+    public String toXML(String s)
     {
         XmlStringBuilder xml = new XmlStringBuilder();
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/AvatarUrl.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/AvatarUrl.java
@@ -84,7 +84,7 @@ public class AvatarUrl
      * Returns xml representation of this extension.
      * @return xml representation of this extension.
      */
-    public String toXML()
+    public String toXML(String s)
     {
         return new XmlStringBuilder()
             .element(getElementName(), getAvatarUrl())

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/Email.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/Email.java
@@ -81,7 +81,7 @@ public class Email
      * Returns xml representation of this extension.
      * @return xml representation of this extension.
      */
-    public String toXML()
+    public String toXML(String s)
     {
         return new XmlStringBuilder()
             .element(ELEMENT_NAME, getAddress())

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/IdentityPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/IdentityPacketExtension.java
@@ -152,7 +152,7 @@ public class IdentityPacketExtension
      * {@inheritDoc}
      */
     @Override
-    public CharSequence toXML()
+    public CharSequence toXML(String s)
     {
         XmlStringBuilder xml = new XmlStringBuilder();
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/StatsId.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/StatsId.java
@@ -84,7 +84,7 @@ public class StatsId
      * Returns xml representation of this extension.
      * @return xml representation of this extension.
      */
-    public String toXML()
+    public String toXML(String s)
     {
         return new XmlStringBuilder()
             .element(ELEMENT_NAME, getStatsId())

--- a/src/main/java/org/jitsi/xmpp/extensions/thumbnail/ThumbnailFile.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/thumbnail/ThumbnailFile.java
@@ -61,7 +61,7 @@ public class ThumbnailFile
      * Represents this <tt>FileElement</tt> in an XML.
      */
     @Override
-    public String toXML()
+    public String toXML(String s)
     {
         XmlStringBuilder xml = new XmlStringBuilder();
 

--- a/src/main/java/org/jitsi/xmpp/extensions/vcardavatar/VCardTempXUpdatePresenceExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/vcardavatar/VCardTempXUpdatePresenceExtension.java
@@ -176,7 +176,7 @@ public class VCardTempXUpdatePresenceExtension
      * @return the packet extension as XML.
      */
     @Override
-    public String toXML()
+    public String toXML(String s)
     {
         return this.xmlString;
     }


### PR DESCRIPTION
This PR updates smack to 4.3.4 and implements the necessary changes.

It is part of an ongoing effort to update smack across the jitsi codebase, so it should not be merged yet.
I still need to create the PRs for the other repos.
See also https://github.com/jitsi/jicoco/pull/81

That being said, it would be great to get the first feedback on this pr already.

The main changes are that XMPPError has been renamed to StanzaError in smack and that toXML now has to pass a String value (can be null).