### PR TITLE
Added mute video moderation feature

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteVideoIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteVideoIq.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.xmpp.extensions.jitsimeet;
+
+import org.jivesoftware.smack.packet.*;
+import org.jxmpp.jid.*;
+
+/**
+ * IQ used for the signaling of video muting functionality in Jitsi Meet
+ * conferences.
+ *
+ * @author Steffen Kolmer
+ */
+public class MuteVideoIq
+    extends IQ
+{
+    /**
+     * Name space of mute packet extension.
+     */
+    public static final String NAMESPACE = "http://jitsi.org/jitmeet/video";
+
+    /**
+     * XML element name of mute packet extension.
+     */
+    public static final String ELEMENT_NAME = "mute";
+
+    /**
+     * Attribute name of "jid".
+     */
+    public static final String JID_ATTR_NAME = "jid";
+
+    /**
+     * Attribute name of "actor".
+     */
+    public static final String ACTOR_ATTR_NAME = "actor";
+
+    /**
+     * Muted peer MUC jid.
+     */
+    private Jid jid;
+
+    /**
+     * The jid of the peer tha initiated the mute, optional.
+     */
+    private Jid actor;
+
+    /**
+     * To mute or unmute.
+     */
+    private Boolean mute;
+
+    /**
+     * Creates a new instance of this class.
+     */
+    public MuteVideoIq()
+    {
+        super(ELEMENT_NAME, NAMESPACE);
+    }
+
+    @Override
+    protected IQChildElementXmlStringBuilder getIQChildElementBuilder(
+            IQChildElementXmlStringBuilder xml)
+    {
+        if (jid != null)
+        {
+            xml.attribute(JID_ATTR_NAME, jid);
+        }
+
+        if (actor != null)
+        {
+            xml.attribute(ACTOR_ATTR_NAME, actor);
+        }
+
+        xml.rightAngleBracket()
+            .append(mute.toString());
+
+        return xml;
+    }
+
+    /**
+     * Sets the MUC jid of the user to be muted/unmuted.
+     * @param jid muc jid in the form of room_name@muc.server.net/nickname.
+     */
+    public void setJid(Jid jid)
+    {
+        this.jid = jid;
+    }
+
+    /**
+     * Returns MUC jid of the participant in the form of
+     * "room_name@muc.server.net/nickname".
+     */
+    public Jid getJid()
+    {
+        return jid;
+    }
+
+    /**
+     * The action contained in the text part of 'mute' XML element body.
+     * @param mute <tt>true</tt> to mute the participant. <tt>null</tt> means no
+     *             action is included in result XML.
+     */
+    public void setMute(Boolean mute)
+    {
+        this.mute = mute;
+    }
+
+    /**
+     * Returns <tt>true</tt> to mute the participant, <tt>false</tt> to unmute
+     * or <tt>null</tt> if the action has not been specified(which is invalid).
+     */
+    public Boolean getMute()
+    {
+        return mute;
+    }
+
+    /**
+     * Returns the peer jid that initiated the mute, if any.
+     * @return the peer jid that initiated the mute.
+     */
+    public Jid getActor()
+    {
+        return actor;
+    }
+
+    /**
+     * Sets jid for the peer that initiated the mute.
+     * @param actor the jid of the peer doing the mute.
+     */
+    public void setActor(Jid actor)
+    {
+        this.actor = actor;
+    }
+}

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteVideoIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteVideoIqProvider.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.xmpp.extensions.jitsimeet;
+
+import org.jivesoftware.smack.provider.*;
+
+import org.jxmpp.jid.*;
+import org.jxmpp.jid.impl.*;
+import org.xmlpull.v1.*;
+
+/**
+ * The parser of {@link MuteVideoIq}.
+ *
+ * @author Steffen Kolmer
+ */
+public class MuteVideoIqProvider
+    extends IQProvider<MuteVideoIq>
+{
+    /**
+     * Registers this IQ provider into given <tt>ProviderManager</tt>.
+     */
+    public static void registerMuteVideoIqProvider()
+    {
+        ProviderManager.addIQProvider(
+            MuteVideoIq.ELEMENT_NAME,
+            MuteVideoIq.NAMESPACE,
+            new MuteVideoIqProvider());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MuteVideoIq parse(XmlPullParser parser, int initialDepth)
+        throws Exception
+    {
+        String namespace = parser.getNamespace();
+
+        // Check the namespace
+        if (!MuteVideoIq.NAMESPACE.equals(namespace))
+        {
+            return null;
+        }
+
+        String rootElement = parser.getName();
+
+        MuteVideoIq iq;
+
+        if (MuteVideoIq.ELEMENT_NAME.equals(rootElement))
+        {
+            iq = new MuteVideoIq();
+            String jidStr = parser.getAttributeValue("", MuteVideoIq.JID_ATTR_NAME);
+            if (jidStr != null)
+            {
+                Jid jid = JidCreate.from(jidStr);
+                iq.setJid(jid);
+            }
+
+            String actorStr
+                = parser.getAttributeValue("", MuteVideoIq.ACTOR_ATTR_NAME);
+            if (actorStr != null)
+            {
+                Jid actor = JidCreate.from(actorStr);
+                iq.setActor(actor);
+            }
+        }
+        else
+        {
+            return null;
+        }
+
+        boolean done = false;
+
+        while (!done)
+        {
+            switch (parser.next())
+            {
+                case XmlPullParser.END_TAG:
+                {
+                    String name = parser.getName();
+
+                    if (rootElement.equals(name))
+                    {
+                        done = true;
+                    }
+                    break;
+                }
+
+                case XmlPullParser.TEXT:
+                {
+                    Boolean mute = Boolean.parseBoolean(parser.getText());
+                    iq.setMute(mute);
+                    break;
+                }
+            }
+        }
+
+        return iq;
+    }
+}


### PR DESCRIPTION
This change adds the ability for a moderator to deactivate the camera of other participants. The implementation uses the same approach that was implemented to mute audio of other participants.

This feature consists of multiple PRs:
- https://github.com/jitsi/jitsi-media-transform/pull/327
- https://github.com/jitsi/jitsi-videobridge/pull/1569
- https://github.com/jitsi/jitsi-xmpp-extensions/pull/37
- https://github.com/jitsi/jicofo/pull/695
- https://github.com/jitsi/lib-jitsi-meet/pull/1496
- https://github.com/jitsi/jitsi-meet/pull/8630