### PR TITLE
Make all XMPP ExtensionElement's have either QNAME or NAMESPACE and ELEMENT fields.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
       <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.11</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -67,12 +73,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
-        <configuration>
-          <includes>
-            <include>**/*TestSuite.*</include>
-          </includes>
-        </configuration>
+        <version>2.22.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/jitsi/xmpp/extensions/AbstractPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/AbstractPacketExtension.java
@@ -160,10 +160,8 @@ public abstract class AbstractPacketExtension
         XmlStringBuilder xml = new XmlStringBuilder();
 
         xml.halfOpenElement(getElementName());
-        if (enclosingNamespace == null || !Objects.equals(enclosingNamespace.getNamespace(), getNamespace()))
-        {
-            xml.xmlnsAttribute(getNamespace());
-        }
+        xml.xmlnsAttribute(getNamespace()); // Only gets written if the namespace != the enclosing namespace
+
 
         //add the rest of the attributes if any
         for (Map.Entry<String, Object> entry : attributes.entrySet())

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/CallInfoPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/CallInfoPacketExtension.java
@@ -33,13 +33,13 @@ public class CallInfoPacketExtension
     /**
      * The name of the element that contains the call info.
      */
-    public static final String ELEMENT_NAME = "call-info";
+    public static final String ELEMENT = "call-info";
 
     /**
      * Constructor.
      */
     public CallInfoPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/CoinIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/CoinIQ.java
@@ -29,7 +29,7 @@ public class CoinIQ
     /**
      * The name of the element that contains the coin data.
      */
-    public static final String ELEMENT_NAME = "conference-info";
+    public static final String ELEMENT = "conference-info";
 
     /**
      * Entity attribute name.
@@ -79,7 +79,7 @@ public class CoinIQ
 
     public CoinIQ()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/CoinIQProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/CoinIQProvider.java
@@ -69,36 +69,36 @@ public class CoinIQProvider
     public CoinIQProvider()
     {
         ProviderManager.addExtensionProvider(
-                UserRolesPacketExtension.ELEMENT_NAME,
+                UserRolesPacketExtension.ELEMENT,
                 UserRolesPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                     <>(UserRolesPacketExtension.class));
 
         ProviderManager.addExtensionProvider(
-                URIPacketExtension.ELEMENT_NAME,
+                URIPacketExtension.ELEMENT,
                 URIPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                     <>(URIPacketExtension.class));
 
         ProviderManager.addExtensionProvider(
-                SIPDialogIDPacketExtension.ELEMENT_NAME,
+                SIPDialogIDPacketExtension.ELEMENT,
                 SIPDialogIDPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                     <>(SIPDialogIDPacketExtension.class));
 
         ProviderManager.addExtensionProvider(
-                ConferenceMediumPacketExtension.ELEMENT_NAME,
+                ConferenceMediumPacketExtension.ELEMENT,
                 ConferenceMediumPacketExtension.NAMESPACE,
                 new ConferenceMediumProvider());
 
         ProviderManager.addExtensionProvider(
-                ConferenceMediaPacketExtension.ELEMENT_NAME,
+                ConferenceMediaPacketExtension.ELEMENT,
                 ConferenceMediaPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <>(ConferenceMediaPacketExtension.class));
 
         ProviderManager.addExtensionProvider(
-                CallInfoPacketExtension.ELEMENT_NAME,
+                CallInfoPacketExtension.ELEMENT,
                 CallInfoPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <>(CallInfoPacketExtension.class));
@@ -148,32 +148,32 @@ public class CoinIQProvider
 
             if (eventType == XmlPullParser.Event.START_ELEMENT)
             {
-                if (elementName.equals(DescriptionPacketExtension.ELEMENT_NAME))
+                if (elementName.equals(DescriptionPacketExtension.ELEMENT))
                 {
                     ExtensionElement childExtension =
                             (ExtensionElement)descriptionProvider.parse(parser);
                     coinIQ.addExtension(childExtension);
                 }
-                else if (elementName.equals(UsersPacketExtension.ELEMENT_NAME))
+                else if (elementName.equals(UsersPacketExtension.ELEMENT))
                 {
                     ExtensionElement childExtension =
                             (ExtensionElement)usersProvider.parse(parser);
                     coinIQ.addExtension(childExtension);
                 }
-                else if (elementName.equals(StatePacketExtension.ELEMENT_NAME))
+                else if (elementName.equals(StatePacketExtension.ELEMENT))
                 {
                     ExtensionElement childExtension =
                             (ExtensionElement)stateProvider.parse(parser);
                     coinIQ.addExtension(childExtension);
                 }
-                else if (elementName.equals(URIsPacketExtension.ELEMENT_NAME))
+                else if (elementName.equals(URIsPacketExtension.ELEMENT))
                 {
                     ExtensionElement childExtension =
                             (ExtensionElement)urisProvider.parse(parser);
                     coinIQ.addExtension(childExtension);
                 }
                 else if (elementName.equals(
-                        SidebarsByValPacketExtension.ELEMENT_NAME))
+                        SidebarsByValPacketExtension.ELEMENT))
                 {
                     ExtensionElement childExtension =
                             (ExtensionElement)sidebarsByValProvider.parse(parser);
@@ -183,7 +183,7 @@ public class CoinIQProvider
 
             if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
-                if (parser.getName().equals(CoinIQ.ELEMENT_NAME))
+                if (parser.getName().equals(CoinIQ.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/ConferenceMediaPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/ConferenceMediaPacketExtension.java
@@ -33,13 +33,13 @@ public class ConferenceMediaPacketExtension
     /**
      * The name of the element that contains the conference media.
      */
-    public static final String ELEMENT_NAME = "available-media";
+    public static final String ELEMENT = "available-media";
 
     /**
      * Constructor.
      */
     public ConferenceMediaPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/ConferenceMediumPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/ConferenceMediumPacketExtension.java
@@ -35,7 +35,7 @@ public class ConferenceMediumPacketExtension
     /**
      * The name of the element that contains the conference medium.
      */
-    public static final String ELEMENT_NAME = "medium";
+    public static final String ELEMENT = "medium";
 
     /**
      * Display text element name.

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/ConferenceMediumProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/ConferenceMediumProvider.java
@@ -90,7 +90,7 @@ public class ConferenceMediumProvider
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
                 if (parser.getName().equals(
-                        ConferenceMediumPacketExtension.ELEMENT_NAME))
+                        ConferenceMediumPacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/DescriptionPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/DescriptionPacketExtension.java
@@ -35,7 +35,7 @@ public class DescriptionPacketExtension
     /**
      * The name of the element that contains the description data.
      */
-    public static final String ELEMENT_NAME = "conference-description";
+    public static final String ELEMENT = "conference-description";
 
     /**
      * Subject element name.
@@ -83,7 +83,7 @@ public class DescriptionPacketExtension
      */
     public DescriptionPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/DescriptionProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/DescriptionProvider.java
@@ -81,7 +81,7 @@ public class DescriptionProvider
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
                 if (parser.getName().equals(
-                        DescriptionPacketExtension.ELEMENT_NAME))
+                        DescriptionPacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/EndpointPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/EndpointPacketExtension.java
@@ -35,7 +35,7 @@ public class EndpointPacketExtension
     /**
      * The name of the element that contains the endpoint data.
      */
-    public static final String ELEMENT_NAME = "endpoint";
+    public static final String ELEMENT = "endpoint";
 
     /**
      * Entity attribute name.
@@ -94,7 +94,7 @@ public class EndpointPacketExtension
      */
     public EndpointPacketExtension(String entity)
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
         setAttribute("entity", entity);
     }
 

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/EndpointProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/EndpointProvider.java
@@ -100,7 +100,7 @@ public class EndpointProvider
                             CoinIQProvider.parseText(parser)));
                 }
                 else if (elementName.equals(
-                        CallInfoPacketExtension.ELEMENT_NAME))
+                        CallInfoPacketExtension.ELEMENT))
                 {
                     ExtensionElementProvider provider
                         = new DefaultPacketExtensionProvider<
@@ -109,7 +109,7 @@ public class EndpointProvider
                             parser);
                     ext.addChildExtension(childExtension);
                 }
-                else if (elementName.equals(MediaPacketExtension.ELEMENT_NAME))
+                else if (elementName.equals(MediaPacketExtension.ELEMENT))
                 {
                     ExtensionElementProvider provider
                         = new MediaProvider();
@@ -121,7 +121,7 @@ public class EndpointProvider
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
                 if (parser.getName().equals(
-                        EndpointPacketExtension.ELEMENT_NAME))
+                        EndpointPacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/HostInfoPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/HostInfoPacketExtension.java
@@ -35,7 +35,7 @@ public class HostInfoPacketExtension
     /**
      * The name of the element that contains the media data.
      */
-    public static final String ELEMENT_NAME = "host-info";
+    public static final String ELEMENT = "host-info";
 
     /**
      * Display text element name.
@@ -62,7 +62,7 @@ public class HostInfoPacketExtension
      */
     public HostInfoPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/MediaPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/MediaPacketExtension.java
@@ -35,7 +35,7 @@ public class MediaPacketExtension
     /**
      * The name of the element that contains the media data.
      */
-    public static final String ELEMENT_NAME = "media";
+    public static final String ELEMENT = "media";
 
     /**
      * Display text element name.
@@ -99,7 +99,7 @@ public class MediaPacketExtension
      */
     public MediaPacketExtension(String id)
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
 
         setAttribute(ID_ATTR_NAME, id);
     }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/MediaProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/MediaProvider.java
@@ -99,7 +99,7 @@ public class MediaProvider
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
                 if (parser.getName().equals(
-                        MediaPacketExtension.ELEMENT_NAME))
+                        MediaPacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/SIPDialogIDPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/SIPDialogIDPacketExtension.java
@@ -35,7 +35,7 @@ public class SIPDialogIDPacketExtension
     /**
      * The name of the element that contains the SIP Dialog ID data.
      */
-    public static final String ELEMENT_NAME = "sip";
+    public static final String ELEMENT = "sip";
 
     /**
      * Display text element name.
@@ -82,7 +82,7 @@ public class SIPDialogIDPacketExtension
      */
     public SIPDialogIDPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/SidebarsByValPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/SidebarsByValPacketExtension.java
@@ -33,13 +33,13 @@ public class SidebarsByValPacketExtension
     /**
      * The name of the element that contains the sidebars by val.
      */
-    public static final String ELEMENT_NAME = "sidebars-by-val";
+    public static final String ELEMENT = "sidebars-by-val";
 
     /**
      * Constructor.
      */
     public SidebarsByValPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/StatePacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/StatePacketExtension.java
@@ -35,7 +35,7 @@ public class StatePacketExtension
     /**
      * The name of the element that contains the state data.
      */
-    public static final String ELEMENT_NAME = "conference-state";
+    public static final String ELEMENT = "conference-state";
 
     /**
      * Users count element name.
@@ -72,7 +72,7 @@ public class StatePacketExtension
      */
     public StatePacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/StateProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/StateProvider.java
@@ -80,7 +80,7 @@ public class StateProvider
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
                 if (parser.getName().equals(
-                        StatePacketExtension.ELEMENT_NAME))
+                        StatePacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/URIPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/URIPacketExtension.java
@@ -35,7 +35,7 @@ public class URIPacketExtension
     /**
      * The name of the element that contains the URI data.
      */
-    public static final String ELEMENT_NAME = "uri";
+    public static final String ELEMENT = "uri";
 
     /**
      * Display text element name.

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/URIsPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/URIsPacketExtension.java
@@ -33,13 +33,13 @@ public class URIsPacketExtension
     /**
      * The name of the element that contains the URIs data.
      */
-    public static final String ELEMENT_NAME = "uris";
+    public static final String ELEMENT = "uris";
 
     /**
      * Constructor.
      */
      public URIsPacketExtension()
      {
-         super(NAMESPACE, ELEMENT_NAME);
+         super(NAMESPACE, ELEMENT);
      }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/UserLanguagesPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/UserLanguagesPacketExtension.java
@@ -35,7 +35,7 @@ public class UserLanguagesPacketExtension
     /**
      * The name of the element that contains the user languages data.
      */
-    public static final String ELEMENT_NAME = "languages";
+    public static final String ELEMENT = "languages";
 
     /**
      * The name of the element that contains the media data.
@@ -52,7 +52,7 @@ public class UserLanguagesPacketExtension
      */
     public UserLanguagesPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/UserLanguagesProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/UserLanguagesProvider.java
@@ -70,7 +70,7 @@ public class UserLanguagesProvider
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
                 if (parser.getName().equals(
-                        UserLanguagesPacketExtension.ELEMENT_NAME))
+                        UserLanguagesPacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/UserPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/UserPacketExtension.java
@@ -35,7 +35,7 @@ public class UserPacketExtension
     /**
      * The name of the element that contains the user data.
      */
-    public static final String ELEMENT_NAME = "user";
+    public static final String ELEMENT = "user";
 
     /**
      * Entity attribute name.
@@ -64,7 +64,7 @@ public class UserPacketExtension
      */
     public UserPacketExtension(String entity)
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
         setAttribute("entity", entity);
     }
 

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/UserProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/UserProvider.java
@@ -83,7 +83,7 @@ public class UserProvider
                     ext.setDisplayText(CoinIQProvider.parseText(parser));
                 }
                 else if (elementName.equals(
-                        EndpointPacketExtension.ELEMENT_NAME))
+                        EndpointPacketExtension.ELEMENT))
                 {
                     ExtensionElementProvider provider
                         = new EndpointProvider();
@@ -95,7 +95,7 @@ public class UserProvider
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
                 if (parser.getName().equals(
-                        UserPacketExtension.ELEMENT_NAME))
+                        UserPacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/UserRolesPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/UserRolesPacketExtension.java
@@ -37,7 +37,7 @@ public class UserRolesPacketExtension
     /**
      * The name of the element that contains the user roles data.
      */
-    public static final String ELEMENT_NAME = "roles";
+    public static final String ELEMENT = "roles";
 
     /**
      * Subject element name.
@@ -54,7 +54,7 @@ public class UserRolesPacketExtension
      */
     public UserRolesPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/UsersPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/UsersPacketExtension.java
@@ -33,7 +33,7 @@ public class UsersPacketExtension
     /**
      * The name of the element that contains the users data.
      */
-    public static final String ELEMENT_NAME = "users";
+    public static final String ELEMENT = "users";
 
     /**
      * Entity attribute name.
@@ -45,6 +45,6 @@ public class UsersPacketExtension
      */
     public UsersPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/coin/UsersProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/coin/UsersProvider.java
@@ -72,7 +72,7 @@ public class UsersProvider
 
             if (eventType == XmlPullParser.Event.START_ELEMENT)
             {
-                if (elementName.equals(UserPacketExtension.ELEMENT_NAME))
+                if (elementName.equals(UserPacketExtension.ELEMENT))
                 {
                     ExtensionElementProvider provider
                         = new UserProvider();
@@ -84,7 +84,7 @@ public class UsersProvider
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
                 if (parser.getName().equals(
-                        UsersPacketExtension.ELEMENT_NAME))
+                        UsersPacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriConferenceIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriConferenceIQ.java
@@ -40,7 +40,7 @@ public class ColibriConferenceIQ
     /**
      * The XML element name of the Jitsi Videobridge <tt>conference</tt> IQ.
      */
-    public static final String ELEMENT_NAME = "conference";
+    public static final String ELEMENT = "conference";
 
     /**
      * The XML name of the <tt>id</tt> attribute of the Jitsi Videobridge
@@ -165,7 +165,7 @@ public class ColibriConferenceIQ
     /** Initializes a new <tt>ColibriConferenceIQ</tt> instance. */
     public ColibriConferenceIQ()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     /**
@@ -535,7 +535,7 @@ public class ColibriConferenceIQ
          * The XML element name of a <tt>channel</tt> of a <tt>content</tt> of a
          * Jitsi Videobridge <tt>conference</tt> IQ.
          */
-        public static final String ELEMENT_NAME = "channel";
+        public static final String ELEMENT = "channel";
 
         /**
          * The XML name of the <tt>host</tt> attribute of a <tt>channel</tt> of
@@ -616,7 +616,7 @@ public class ColibriConferenceIQ
          * element and which identifies/specifies an (RTP) SSRC which has been
          * seen/received on the respective <tt>Channel</tt>.
          */
-        public static final String SSRC_ELEMENT_NAME = "ssrc";
+        public static final String SSRC_ELEMENT = "ssrc";
 
         /**
          * The direction of the <tt>channel</tt> represented by this instance.
@@ -723,7 +723,7 @@ public class ColibriConferenceIQ
         /** Initializes a new <tt>Channel</tt> instance. */
         public Channel()
         {
-            super(Channel.ELEMENT_NAME);
+            super(Channel.ELEMENT);
         }
 
         /**
@@ -1154,7 +1154,7 @@ public class ColibriConferenceIQ
 
             for (int i = 0; i < ssrcs.length; i++)
             {
-                xml.element(SSRC_ELEMENT_NAME,
+                xml.element(SSRC_ELEMENT,
                     Long.toString(ssrcs[i] & 0xFFFFFFFFL));
             }
 
@@ -1432,7 +1432,7 @@ public class ColibriConferenceIQ
         /**
          * The name of the "relay" child element of an {@link OctoChannel}.
          */
-        public static final String RELAY_ELEMENT_NAME = "relay";
+        public static final String RELAY_ELEMENT = "relay";
 
         /**
          * The name of the "id" attribute of child elements with name "relay".
@@ -1508,7 +1508,7 @@ public class ColibriConferenceIQ
             super.printContent(xml);
             for (String relay : relays)
             {
-                xml.halfOpenElement(RELAY_ELEMENT_NAME)
+                xml.halfOpenElement(RELAY_ELEMENT)
                     .attribute(ID_ATTR_NAME, relay)
                     .closeEmptyElement();
             }
@@ -1525,7 +1525,7 @@ public class ColibriConferenceIQ
         /**
          * The name of the "channel-bundle" element.
          */
-        public static final String ELEMENT_NAME = "channel-bundle";
+        public static final String ELEMENT = "channel-bundle";
 
         /**
          * The name of the "id" attribute.
@@ -1595,14 +1595,14 @@ public class ColibriConferenceIQ
         public IQChildElementXmlStringBuilder toXML(
             IQChildElementXmlStringBuilder xml)
         {
-            xml.halfOpenElement(ELEMENT_NAME)
+            xml.halfOpenElement(ELEMENT)
                 .attribute(ID_ATTR_NAME, id);
 
             if (transport != null)
             {
                 xml.rightAngleBracket();
                 xml.append(transport.toXML());
-                xml.closeElement(ELEMENT_NAME);
+                xml.closeElement(ELEMENT);
             }
             else
             {
@@ -1967,7 +1967,7 @@ public class ColibriConferenceIQ
          * The XML element name of a <tt>content</tt> of a Jitsi Videobridge
          * <tt>conference</tt> IQ.
          */
-        public static final String ELEMENT_NAME = "content";
+        public static final String ELEMENT = "content";
 
         /**
          * The XML name of the <tt>name</tt> attribute of a <tt>content</tt> of
@@ -2202,7 +2202,7 @@ public class ColibriConferenceIQ
         public IQChildElementXmlStringBuilder toXML(
             IQChildElementXmlStringBuilder xml)
         {
-            xml.halfOpenElement(ELEMENT_NAME)
+            xml.halfOpenElement(ELEMENT)
                 .attribute(NAME_ATTR_NAME, getName());
 
             List<Channel> channels = getChannels();
@@ -2225,7 +2225,7 @@ public class ColibriConferenceIQ
                     conn.toXML(xml);
                 }
 
-                xml.closeElement(ELEMENT_NAME);
+                xml.closeElement(ELEMENT);
             }
 
             return xml;
@@ -2256,7 +2256,7 @@ public class ColibriConferenceIQ
         /**
          * The name of the 'endpoint' element.
          */
-        public static final String ELEMENT_NAME = "endpoint";
+        public static final String ELEMENT = "endpoint";
 
         /**
          * The name of the 'id' attribute.
@@ -2362,7 +2362,7 @@ public class ColibriConferenceIQ
         public IQChildElementXmlStringBuilder toXML(
             IQChildElementXmlStringBuilder xml)
         {
-            xml.halfOpenElement(ELEMENT_NAME)
+            xml.halfOpenElement(ELEMENT)
                 .attribute(ID_ATTR_NAME, id);
 
             xml.optAttribute(DISPLAYNAME_ATTR_NAME, displayName);
@@ -2381,7 +2381,7 @@ public class ColibriConferenceIQ
         /**
          * The XML name of the <tt>recording</tt> element.
          */
-        public static final String ELEMENT_NAME = "recording";
+        public static final String ELEMENT = "recording";
 
         /**
          * The XML name of the <tt>path</tt> attribute.
@@ -2479,7 +2479,7 @@ public class ColibriConferenceIQ
 
         public IQChildElementXmlStringBuilder toXML(IQChildElementXmlStringBuilder xml)
         {
-            xml.halfOpenElement(ELEMENT_NAME)
+            xml.halfOpenElement(ELEMENT)
                 .attribute(STATE_ATTR_NAME, state.toString())
                 .optAttribute(TOKEN_ATTR_NAME, token)
                 .optAttribute(DIRECTORY_ATTR_NAME, directory)
@@ -2551,19 +2551,19 @@ public class ColibriConferenceIQ
     public static class GracefulShutdown
         extends AbstractPacketExtension
     {
-        public static final String ELEMENT_NAME = "graceful-shutdown";
+        public static final String ELEMENT = "graceful-shutdown";
 
         public static final String NAMESPACE = ColibriConferenceIQ.NAMESPACE;
 
         public GracefulShutdown()
         {
-            super(ColibriConferenceIQ.NAMESPACE, ELEMENT_NAME);
+            super(ColibriConferenceIQ.NAMESPACE, ELEMENT);
         }
     }
 
     public static class RTCPTerminationStrategy
     {
-        public static final String ELEMENT_NAME = "rtcp-termination-strategy";
+        public static final String ELEMENT = "rtcp-termination-strategy";
 
         public static final String NAME_ATTR_NAME = "name";
 
@@ -2581,7 +2581,7 @@ public class ColibriConferenceIQ
 
         public IQChildElementXmlStringBuilder toXML(IQChildElementXmlStringBuilder xml)
         {
-            xml.halfOpenElement(ELEMENT_NAME)
+            xml.halfOpenElement(ELEMENT)
                 .attribute(NAME_ATTR_NAME, name)
                 .closeEmptyElement();
             return xml;
@@ -2601,7 +2601,7 @@ public class ColibriConferenceIQ
          * The XML element name of a <tt>content</tt> of a Jitsi Videobridge
          * <tt>conference</tt> IQ.
          */
-        public static final String ELEMENT_NAME = "sctpconnection";
+        public static final String ELEMENT = "sctpconnection";
 
         /**
          * The XML name of the <tt>port</tt> attribute of a
@@ -2622,7 +2622,7 @@ public class ColibriConferenceIQ
          */
         public SctpConnection()
         {
-            super(SctpConnection.ELEMENT_NAME);
+            super(SctpConnection.ELEMENT);
         }
 
         /**

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriIQProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriIQProvider.java
@@ -50,32 +50,32 @@ public class ColibriIQProvider
     public ColibriIQProvider()
     {
         ProviderManager.addExtensionProvider(
-                PayloadTypePacketExtension.ELEMENT_NAME,
+                PayloadTypePacketExtension.ELEMENT,
                 ColibriConferenceIQ.NAMESPACE,
                 new DefaultPacketExtensionProvider<>(
                         PayloadTypePacketExtension.class));
         ProviderManager.addExtensionProvider(
-                RtcpFbPacketExtension.ELEMENT_NAME,
+                RtcpFbPacketExtension.ELEMENT,
                 RtcpFbPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<>(
                         RtcpFbPacketExtension.class));
         ProviderManager.addExtensionProvider(
-                RTPHdrExtPacketExtension.ELEMENT_NAME,
+                RTPHdrExtPacketExtension.ELEMENT,
                 ColibriConferenceIQ.NAMESPACE,
                 new DefaultPacketExtensionProvider<>(
                         RTPHdrExtPacketExtension.class));
         ProviderManager.addExtensionProvider(
-                SourcePacketExtension.ELEMENT_NAME,
+                SourcePacketExtension.ELEMENT,
                 SourcePacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<>(
                         SourcePacketExtension.class));
         ProviderManager.addExtensionProvider(
-                SourceGroupPacketExtension.ELEMENT_NAME,
+                SourceGroupPacketExtension.ELEMENT,
                 SourceGroupPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<>(
                         SourceGroupPacketExtension.class));
         ProviderManager.addExtensionProvider(
-                SourceRidGroupPacketExtension.ELEMENT_NAME,
+                SourceRidGroupPacketExtension.ELEMENT,
                 SourceRidGroupPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<>(
                         SourceRidGroupPacketExtension.class));
@@ -85,11 +85,11 @@ public class ColibriIQProvider
                 ParameterPacketExtension.class);
 
         ProviderManager.addExtensionProvider(
-                ParameterPacketExtension.ELEMENT_NAME,
+                ParameterPacketExtension.ELEMENT,
                 ColibriConferenceIQ.NAMESPACE,
                 parameterProvider);
         ProviderManager.addExtensionProvider(
-                ParameterPacketExtension.ELEMENT_NAME,
+                ParameterPacketExtension.ELEMENT,
                 SourcePacketExtension.NAMESPACE,
                 parameterProvider);
         // Shutdown IQ
@@ -107,13 +107,13 @@ public class ColibriIQProvider
                     ColibriConferenceIQ.GracefulShutdown.class);
 
         ProviderManager.addExtensionProvider(
-                ColibriConferenceIQ.GracefulShutdown.ELEMENT_NAME,
+                ColibriConferenceIQ.GracefulShutdown.ELEMENT,
                 ColibriConferenceIQ.GracefulShutdown.NAMESPACE,
                 shutdownProvider);
 
         // ColibriStatsIQ
         ProviderManager.addIQProvider(
-                ColibriStatsIQ.ELEMENT_NAME,
+                ColibriStatsIQ.ELEMENT,
                 ColibriStatsIQ.NAMESPACE,
                 this);
 
@@ -123,7 +123,7 @@ public class ColibriIQProvider
                 ColibriStatsExtension.class);
 
         ProviderManager.addExtensionProvider(
-                ColibriStatsExtension.ELEMENT_NAME,
+                ColibriStatsExtension.ELEMENT,
                 ColibriStatsExtension.NAMESPACE,
                 statsProvider);
         // ColibriStatsExtension.Stat
@@ -132,13 +132,13 @@ public class ColibriIQProvider
                     ColibriStatsExtension.Stat.class);
 
         ProviderManager.addExtensionProvider(
-                ColibriStatsExtension.Stat.ELEMENT_NAME,
+                ColibriStatsExtension.Stat.ELEMENT,
                 ColibriStatsExtension.NAMESPACE,
                 statProvider);
 
         // ssrc-info
         ProviderManager.addExtensionProvider(
-            SSRCInfoPacketExtension.ELEMENT_NAME,
+            SSRCInfoPacketExtension.ELEMENT,
             SSRCInfoPacketExtension.NAMESPACE,
             new DefaultPacketExtensionProvider<>(
                 SSRCInfoPacketExtension.class));
@@ -270,7 +270,7 @@ public class ColibriIQProvider
         String namespace = parser.getNamespace();
         IQ iq;
 
-        if (ColibriConferenceIQ.ELEMENT_NAME.equals(parser.getName())
+        if (ColibriConferenceIQ.ELEMENT.equals(parser.getName())
                 && ColibriConferenceIQ.NAMESPACE.equals(namespace))
         {
             ColibriConferenceIQ conference = new ColibriConferenceIQ();
@@ -318,17 +318,17 @@ public class ColibriIQProvider
                 {
                     String name = parser.getName();
 
-                    if (ColibriConferenceIQ.ELEMENT_NAME.equals(name))
+                    if (ColibriConferenceIQ.ELEMENT.equals(name))
                     {
                         done = true;
                     }
-                    else if (ColibriConferenceIQ.Channel.ELEMENT_NAME.equals(
+                    else if (ColibriConferenceIQ.Channel.ELEMENT.equals(
                             name))
                     {
                         content.addChannel(channel);
                         channel = null;
                     }
-                    else if (ColibriConferenceIQ.SctpConnection.ELEMENT_NAME
+                    else if (ColibriConferenceIQ.SctpConnection.ELEMENT
                             .equals(name))
                     {
                         if (sctpConnection != null)
@@ -336,7 +336,7 @@ public class ColibriIQProvider
 
                         sctpConnection = null;
                     }
-                    else if (ColibriConferenceIQ.ChannelBundle.ELEMENT_NAME
+                    else if (ColibriConferenceIQ.ChannelBundle.ELEMENT
                             .equals(name))
                     {
                         if (bundle != null)
@@ -351,7 +351,7 @@ public class ColibriIQProvider
                             bundle = null;
                         }
                     }
-                    else if (ColibriConferenceIQ.Endpoint.ELEMENT_NAME
+                    else if (ColibriConferenceIQ.Endpoint.ELEMENT
                             .equals(name))
                     {
                         if (conference.addEndpoint(conferenceEndpoint) != null)
@@ -362,7 +362,7 @@ public class ColibriIQProvider
                         }
                         conferenceEndpoint = null;
                     }
-                    else if (ColibriConferenceIQ.Channel.SSRC_ELEMENT_NAME
+                    else if (ColibriConferenceIQ.Channel.SSRC_ELEMENT
                             .equals(name))
                     {
                         String s = ssrc.toString().trim();
@@ -384,26 +384,26 @@ public class ColibriIQProvider
                         }
                         ssrc = null;
                     }
-                    else if (ColibriConferenceIQ.Content.ELEMENT_NAME.equals(
+                    else if (ColibriConferenceIQ.Content.ELEMENT.equals(
                             name))
                     {
                         conference.addContent(content);
                         content = null;
                     }
                     else if (ColibriConferenceIQ.RTCPTerminationStrategy
-                            .ELEMENT_NAME.equals(name))
+                            .ELEMENT.equals(name))
                     {
                         conference.setRTCPTerminationStrategy(
                                 rtcpTerminationStrategy);
                         rtcpTerminationStrategy = null;
                     }
-                    else if (ColibriConferenceIQ.Recording.ELEMENT_NAME.equals(
+                    else if (ColibriConferenceIQ.Recording.ELEMENT.equals(
                             name))
                     {
                         conference.setRecording(recording);
                         recording = null;
                     }
-                    else if (ColibriConferenceIQ.GracefulShutdown.ELEMENT_NAME
+                    else if (ColibriConferenceIQ.GracefulShutdown.ELEMENT
                         .equals(name))
                     {
                         conference.setGracefulShutdown(true);
@@ -415,7 +415,7 @@ public class ColibriIQProvider
                 {
                     String name = parser.getName();
 
-                    if (ColibriConferenceIQ.Channel.ELEMENT_NAME.equals(name))
+                    if (ColibriConferenceIQ.Channel.ELEMENT.equals(name))
                     {
                         String type
                             = parser.getAttributeValue(
@@ -589,7 +589,7 @@ public class ColibriIQProvider
                         }
                     }
                     else if (ColibriConferenceIQ.ChannelBundle
-                            .ELEMENT_NAME.equals(name))
+                            .ELEMENT.equals(name))
                     {
                         String bundleId
                             = parser.getAttributeValue(
@@ -604,7 +604,7 @@ public class ColibriIQProvider
                         }
                     }
                     else if (ColibriConferenceIQ.RTCPTerminationStrategy
-                            .ELEMENT_NAME.equals(name))
+                            .ELEMENT.equals(name))
                     {
                         rtcpTerminationStrategy =
                                 new ColibriConferenceIQ.RTCPTerminationStrategy();
@@ -622,7 +622,7 @@ public class ColibriIQProvider
 
                     }
                     else if (ColibriConferenceIQ.OctoChannel
-                                    .RELAY_ELEMENT_NAME.equals(name))
+                                    .RELAY_ELEMENT.equals(name))
                     {
                         String id
                             = parser.getAttributeValue(
@@ -636,12 +636,12 @@ public class ColibriIQProvider
                                 .addRelay(id);
                         }
                     }
-                    else if (ColibriConferenceIQ.Channel.SSRC_ELEMENT_NAME
+                    else if (ColibriConferenceIQ.Channel.SSRC_ELEMENT
                             .equals(name))
                     {
                         ssrc = new StringBuilder();
                     }
-                    else if (ColibriConferenceIQ.Content.ELEMENT_NAME.equals(
+                    else if (ColibriConferenceIQ.Content.ELEMENT.equals(
                             name))
                     {
                         content = new ColibriConferenceIQ.Content();
@@ -655,7 +655,7 @@ public class ColibriIQProvider
                                 && (contentName.length() != 0))
                             content.setName(contentName);
                     }
-                    else if (ColibriConferenceIQ.Recording.ELEMENT_NAME.equals(
+                    else if (ColibriConferenceIQ.Recording.ELEMENT.equals(
                             name))
                     {
                         String stateStr
@@ -672,7 +672,7 @@ public class ColibriIQProvider
                                 stateStr,
                                 token);
                     }
-                    else if (ColibriConferenceIQ.SctpConnection.ELEMENT_NAME
+                    else if (ColibriConferenceIQ.SctpConnection.ELEMENT
                         .equals(name))
                     {
                         // Endpoint
@@ -745,7 +745,7 @@ public class ColibriIQProvider
                         if (isNotEmpty(expire))
                             sctpConnection.setExpire(Integer.parseInt(expire));
                     }
-                    else if (ColibriConferenceIQ.Endpoint.ELEMENT_NAME
+                    else if (ColibriConferenceIQ.Endpoint.ELEMENT
                             .equals(name))
                     {
                         String id
@@ -779,7 +779,7 @@ public class ColibriIQProvider
                         String peName = null;
                         String peNamespace = null;
 
-                        if (IceUdpTransportPacketExtension.ELEMENT_NAME
+                        if (IceUdpTransportPacketExtension.ELEMENT
                                     .equals(name)
                                 && IceUdpTransportPacketExtension.NAMESPACE
                                         .equals(parser.getNamespace()))
@@ -788,7 +788,7 @@ public class ColibriIQProvider
                             peNamespace
                                 = IceUdpTransportPacketExtension.NAMESPACE;
                         }
-                        else if (PayloadTypePacketExtension.ELEMENT_NAME.equals(
+                        else if (PayloadTypePacketExtension.ELEMENT.equals(
                                 name))
                         {
                             /*
@@ -799,7 +799,7 @@ public class ColibriIQProvider
                             peName = name;
                             peNamespace = namespace;
                         }
-                        else if (RtcpFbPacketExtension.ELEMENT_NAME.equals(
+                        else if (RtcpFbPacketExtension.ELEMENT.equals(
                                 name)
                                 && RtcpFbPacketExtension.NAMESPACE
                                 .equals(parser.getNamespace()))
@@ -812,7 +812,7 @@ public class ColibriIQProvider
                             peName = name;
                             peNamespace = namespace;
                         }
-                        else if (RTPHdrExtPacketExtension.ELEMENT_NAME.equals(
+                        else if (RTPHdrExtPacketExtension.ELEMENT.equals(
                                 name))
                         {
                             /*
@@ -823,7 +823,7 @@ public class ColibriIQProvider
                             peName = name;
                             peNamespace = namespace;
                         }
-                        else if (RawUdpTransportPacketExtension.ELEMENT_NAME
+                        else if (RawUdpTransportPacketExtension.ELEMENT
                                     .equals(name)
                                 && RawUdpTransportPacketExtension.NAMESPACE
                                         .equals(parser.getNamespace()))
@@ -832,14 +832,14 @@ public class ColibriIQProvider
                             peNamespace
                                 = RawUdpTransportPacketExtension.NAMESPACE;
                         }
-                        else if (SourcePacketExtension.ELEMENT_NAME.equals(name)
+                        else if (SourcePacketExtension.ELEMENT.equals(name)
                                 && SourcePacketExtension.NAMESPACE.equals(
                                         parser.getNamespace()))
                         {
                             peName = name;
                             peNamespace = SourcePacketExtension.NAMESPACE;
                         }
-                        else if (SourceGroupPacketExtension.ELEMENT_NAME
+                        else if (SourceGroupPacketExtension.ELEMENT
                                                 .equals(name)
                                 && SourceGroupPacketExtension.NAMESPACE
                                                 .equals(parser.getNamespace()))
@@ -847,7 +847,7 @@ public class ColibriIQProvider
                             peName = name;
                             peNamespace = SourceGroupPacketExtension.NAMESPACE;
                         }
-                        else if (SourceRidGroupPacketExtension.ELEMENT_NAME
+                        else if (SourceRidGroupPacketExtension.ELEMENT
                                                 .equals(name)
                                 && SourceRidGroupPacketExtension.NAMESPACE
                                                 .equals(parser.getNamespace()))
@@ -922,7 +922,7 @@ public class ColibriIQProvider
                 }
             }
         }
-        else if (ColibriStatsIQ.ELEMENT_NAME.equals(parser.getName())
+        else if (ColibriStatsIQ.ELEMENT.equals(parser.getName())
             && ColibriStatsIQ.NAMESPACE.equals(namespace))
         {
             String rootElement = parser.getName();
@@ -942,7 +942,7 @@ public class ColibriIQProvider
                         String name = parser.getName();
 
                         if (ColibriStatsExtension.Stat
-                                    .ELEMENT_NAME.equals(name))
+                                    .ELEMENT.equals(name))
                         {
                             stat = new ColibriStatsExtension.Stat();
 
@@ -968,7 +968,7 @@ public class ColibriIQProvider
                         {
                             done = true;
                         }
-                        else if (ColibriStatsExtension.Stat.ELEMENT_NAME
+                        else if (ColibriStatsExtension.Stat.ELEMENT
                             .equals(name))
                         {
                             if (stat != null)

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriStatsExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriStatsExtension.java
@@ -23,6 +23,8 @@ import org.jitsi.utils.logging2.*;
 import org.jivesoftware.smack.packet.*;
 import org.jivesoftware.smack.util.*;
 
+import javax.xml.namespace.*;
+
 /**
  * Implements the Jitsi Videobridge <tt>stats</tt> extension within COnferencing
  * with LIghtweight BRIdging that will provide various statistics.
@@ -41,7 +43,7 @@ public class ColibriStatsExtension
     /**
      * The XML element name of the Jitsi Videobridge <tt>stats</tt> extension.
      */
-    public static final String ELEMENT_NAME = "stats";
+    public static final String ELEMENT = "stats";
 
     /**
      * The XML COnferencing with LIghtweight BRIdging namespace of the Jitsi
@@ -482,7 +484,7 @@ public class ColibriStatsExtension
      */
     public ColibriStatsExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -582,7 +584,12 @@ public class ColibriStatsExtension
          * The XML element name of a <tt>content</tt> of a Jitsi Videobridge
          * <tt>stats</tt> IQ.
          */
-        public static final String ELEMENT_NAME = "stat";
+        public static final String ELEMENT = "stat";
+
+        /**
+         * The qualified name of this element.
+         */
+        public static final QName QNAME = new QName(NAMESPACE, ELEMENT);
 
         /**
          * The XML name of the <tt>name</tt> attribute of a <tt>stat</tt> of a
@@ -600,7 +607,7 @@ public class ColibriStatsExtension
 
         public Stat()
         {
-            super(NAMESPACE, ELEMENT_NAME);
+            super(NAMESPACE, ELEMENT);
         }
 
         /**
@@ -618,7 +625,7 @@ public class ColibriStatsExtension
         @Override
         public String getElementName()
         {
-            return ELEMENT_NAME;
+            return ELEMENT;
         }
 
         /**
@@ -672,7 +679,7 @@ public class ColibriStatsExtension
             else
             {
                 return new XmlStringBuilder()
-                    .halfOpenElement(ELEMENT_NAME)
+                    .halfOpenElement(ELEMENT)
                     .attribute(NAME_ATTR_NAME, name)
                     .attribute(VALUE_ATTR_NAME, value.toString())
                     .closeEmptyElement()

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriStatsIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/ColibriStatsIQ.java
@@ -29,8 +29,8 @@ public class ColibriStatsIQ
     /**
      * The XML element name of the Jitsi Videobridge <tt>stats</tt> extension.
      */
-    public static final String ELEMENT_NAME
-        = ColibriStatsExtension.ELEMENT_NAME;
+    public static final String ELEMENT
+        = ColibriStatsExtension.ELEMENT;
 
     /**
      * The XML COnferencing with LIghtweight BRIdging namespace of the Jitsi
@@ -44,7 +44,7 @@ public class ColibriStatsIQ
 
     public ColibriStatsIQ()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     @Override

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/SourcePacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/SourcePacketExtension.java
@@ -40,7 +40,7 @@ public class SourcePacketExtension
      * The XML name of the <tt>setup</tt> element defined by Source-Specific
      * Media Attributes in Jingle.
      */
-    public static final String ELEMENT_NAME = "source";
+    public static final String ELEMENT = "source";
 
     /**
      * The XML namespace of the <tt>setup</tt> element defined by
@@ -75,7 +75,7 @@ public class SourcePacketExtension
     /** Initializes a new <tt>SourcePacketExtension</tt> instance. */
     public SourcePacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/WebSocketPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/WebSocketPacketExtension.java
@@ -25,7 +25,7 @@ public class WebSocketPacketExtension extends AbstractPacketExtension
     /**
      * The name of the "web-socket" element.
      */
-    public static final String ELEMENT_NAME = "web-socket";
+    public static final String ELEMENT = "web-socket";
 
     public static final String NAMESPACE = ColibriConferenceIQ.NAMESPACE;
 
@@ -39,7 +39,7 @@ public class WebSocketPacketExtension extends AbstractPacketExtension
      */
     public WebSocketPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -47,7 +47,7 @@ public class WebSocketPacketExtension extends AbstractPacketExtension
      */
     public WebSocketPacketExtension(String url)
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
         setUrl(url);
     }
 

--- a/src/main/java/org/jitsi/xmpp/extensions/condesc/CallIdExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/condesc/CallIdExtension.java
@@ -35,7 +35,7 @@ public class CallIdExtension
     /**
      * The name of the "callid" element.
      */
-    public static final String ELEMENT_NAME = "callid";
+    public static final String ELEMENT = "callid";
 
     /**
      * Creates a new instance setting the text to <tt>callid</tt>.
@@ -54,6 +54,6 @@ public class CallIdExtension
      */
     public CallIdExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/condesc/ConferenceDescriptionExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/condesc/ConferenceDescriptionExtension.java
@@ -37,7 +37,7 @@ public class ConferenceDescriptionExtension
     /**
      * The name of the "conference" XML element.
      */
-    public static final String ELEMENT_NAME = "conference";
+    public static final String ELEMENT = "conference";
 
     /**
      * The name of the "uri" attribute.
@@ -104,7 +104,7 @@ public class ConferenceDescriptionExtension
     public ConferenceDescriptionExtension(
             String uri, String callId, String password)
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
 
         if (uri != null)
             setUri(uri);

--- a/src/main/java/org/jitsi/xmpp/extensions/condesc/ConferenceDescriptionExtensionProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/condesc/ConferenceDescriptionExtensionProvider.java
@@ -64,7 +64,7 @@ public class ConferenceDescriptionExtensionProvider
             {
                 case START_ELEMENT:
                     elementName = parser.getName();
-                    if (TransportExtension.ELEMENT_NAME.equals(elementName))
+                    if (TransportExtension.ELEMENT.equals(elementName))
                     {
                         String transportNs = parser.getNamespace();
                         if (transportNs != null)
@@ -78,11 +78,11 @@ public class ConferenceDescriptionExtensionProvider
                 case END_ELEMENT:
                     switch (parser.getName())
                     {
-                        case ConferenceDescriptionExtension.ELEMENT_NAME:
+                        case ConferenceDescriptionExtension.ELEMENT:
                             done = true;
                             break;
 
-                        case TransportExtension.ELEMENT_NAME:
+                        case TransportExtension.ELEMENT:
                             if (transportExt != null)
                             {
                                 packetExtension.addChildExtension(transportExt);

--- a/src/main/java/org/jitsi/xmpp/extensions/condesc/TransportExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/condesc/TransportExtension.java
@@ -26,7 +26,7 @@ public class TransportExtension
     /**
      * The name of the "transport" element.
      */
-    public static final String ELEMENT_NAME = "transport";
+    public static final String ELEMENT = "transport";
 
     /**
      * Creates a new instance and sets the XML namespace to
@@ -36,6 +36,6 @@ public class TransportExtension
      */
     public TransportExtension(String namespace)
     {
-        super(namespace, TransportExtension.ELEMENT_NAME);
+        super(namespace, TransportExtension.ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/health/HealthCheckIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/health/HealthCheckIQ.java
@@ -28,7 +28,7 @@ public class HealthCheckIQ
     /**
      * Health check IQ element name.
      */
-    final static public String ELEMENT_NAME = "healthcheck";
+    final static public String ELEMENT = "healthcheck";
 
     /**
      * XML namespace name for health check IQs.
@@ -38,7 +38,7 @@ public class HealthCheckIQ
 
     public HealthCheckIQ()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/health/HealthCheckIQProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/health/HealthCheckIQProvider.java
@@ -39,7 +39,7 @@ public class HealthCheckIQProvider
     {
         // ColibriStatsIQ
         ProviderManager.addIQProvider(
-            HealthCheckIQ.ELEMENT_NAME,
+            HealthCheckIQ.ELEMENT,
             HealthCheckIQ.NAMESPACE,
             new HealthCheckIQProvider());
     }
@@ -56,7 +56,7 @@ public class HealthCheckIQProvider
         String namespace = parser.getNamespace();
         IQ iq;
 
-        if (HealthCheckIQ.ELEMENT_NAME.equals(parser.getName())
+        if (HealthCheckIQ.ELEMENT.equals(parser.getName())
             && HealthCheckIQ.NAMESPACE.equals(namespace))
         {
             String rootElement = parser.getName();

--- a/src/main/java/org/jitsi/xmpp/extensions/health/HealthStatusPacketExt.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/health/HealthStatusPacketExt.java
@@ -42,16 +42,16 @@ public class HealthStatusPacketExt
     final static public String NAMESPACE
             = "http://jitsi.org/protocol/health";
 
-    public static final String ELEMENT_NAME = "health-status";
+    public static final String ELEMENT = "health-status";
 
     private static final String HEALTH_ATTRIBUTE = "status";
 
-    public HealthStatusPacketExt() { super(NAMESPACE, ELEMENT_NAME); }
+    public HealthStatusPacketExt() { super(NAMESPACE, ELEMENT); }
 
     static public void registerExtensionProvider()
     {
         ProviderManager.addExtensionProvider(
-                ELEMENT_NAME,
+                ELEMENT,
                 NAMESPACE,
                 new DefaultPacketExtensionProvider<>(HealthStatusPacketExt.class)
         );

--- a/src/main/java/org/jitsi/xmpp/extensions/inputevt/InputEvtIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/inputevt/InputEvtIQ.java
@@ -51,7 +51,7 @@ public class InputEvtIQ extends IQ
     /**
      * The name of the element that contains the input event data.
      */
-    public static final String ELEMENT_NAME = "inputevt";
+    public static final String ELEMENT = "inputevt";
 
     /**
      * The name of the argument that contains the input action value.
@@ -74,7 +74,7 @@ public class InputEvtIQ extends IQ
      */
     public InputEvtIQ()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/inputevt/InputEvtIQProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/inputevt/InputEvtIQProvider.java
@@ -71,7 +71,7 @@ public class InputEvtIQProvider
                 break;
 
             case END_ELEMENT:
-                if (InputEvtIQ.ELEMENT_NAME.equals(parser.getName()))
+                if (InputEvtIQ.ELEMENT.equals(parser.getName()))
                     done = true;
                 break;
             }

--- a/src/main/java/org/jitsi/xmpp/extensions/inputevt/RemoteControlExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/inputevt/RemoteControlExtension.java
@@ -18,7 +18,10 @@ package org.jitsi.xmpp.extensions.inputevt;
 import java.awt.*;
 import java.awt.event.*;
 
+import org.jitsi.xmpp.extensions.rayo.*;
 import org.jivesoftware.smack.packet.*;
+
+import javax.xml.namespace.*;
 
 /**
  * This class implements input event extension.
@@ -37,6 +40,12 @@ public class RemoteControlExtension
      * Size of the panel that contains video
      */
     private final Dimension videoPanelSize;
+
+    /**
+     * Qualified name of element.
+     */
+    public static final QName QNAME = new QName(RemoteControlExtensionProvider.NAMESPACE,
+        RemoteControlExtensionProvider.ELEMENT_REMOTE_CONTROL);
 
     /**
      * Constructor.

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriBusyStatusPacketExt.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriBusyStatusPacketExt.java
@@ -40,7 +40,7 @@ public class JibriBusyStatusPacketExt
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "busy-status";
+    public static final String ELEMENT = "busy-status";
 
     private static final String STATUS_ATTRIBUTE = "status";
 
@@ -49,13 +49,13 @@ public class JibriBusyStatusPacketExt
      */
     public JibriBusyStatusPacketExt()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     static public void registerExtensionProvider()
     {
         ProviderManager.addExtensionProvider(
-                ELEMENT_NAME,
+                ELEMENT,
                 NAMESPACE,
                 new DefaultPacketExtensionProvider<>(JibriBusyStatusPacketExt.class)
         );

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
@@ -58,7 +58,7 @@ public class JibriIq
     /**
      * XML element name of the Jibri IQ.
      */
-    public static final String ELEMENT_NAME = "jibri";
+    public static final String ELEMENT = "jibri";
 
     /**
      * XML namespace of the Jibri IQ.
@@ -205,7 +205,7 @@ public class JibriIq
 
     public JibriIq()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
@@ -51,7 +51,7 @@ public class JibriIqProvider
 
         JibriIq iq;
 
-        if (JibriIq.ELEMENT_NAME.equals(rootElement))
+        if (JibriIq.ELEMENT.equals(rootElement))
         {
             iq = new JibriIq();
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriStatusPacketExt.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriStatusPacketExt.java
@@ -38,20 +38,20 @@ public class JibriStatusPacketExt
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "jibri-status";
+    public static final String ELEMENT = "jibri-status";
 
     /**
      * Creates new instance of <tt>VideoMutedExtension</tt>.
      */
     public JibriStatusPacketExt()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     static public void registerExtensionProvider()
     {
         ProviderManager.addExtensionProvider(
-                ELEMENT_NAME,
+                ELEMENT,
                 NAMESPACE,
                 new DefaultPacketExtensionProvider<>(JibriStatusPacketExt.class)
         );

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/RecordingStatus.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/RecordingStatus.java
@@ -43,7 +43,7 @@ public class RecordingStatus
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "jibri-recording-status";
+    public static final String ELEMENT = "jibri-recording-status";
 
     /**
      * The name of XML attribute which holds the recording status.
@@ -62,7 +62,7 @@ public class RecordingStatus
 
     public RecordingStatus()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/SipCallState.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/SipCallState.java
@@ -40,7 +40,7 @@ public class SipCallState
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "jibri-sip-call-state";
+    public static final String ELEMENT = "jibri-sip-call-state";
 
     /**
      * The name of XML attribute which holds the SIP session state.
@@ -54,7 +54,7 @@ public class SipCallState
 
     public SipCallState()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/BandwidthPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/BandwidthPacketExtension.java
@@ -29,7 +29,7 @@ public class BandwidthPacketExtension
     /**
      * The name of the "bandwidth" element.
      */
-    public static final String ELEMENT_NAME = "bandwidth";
+    public static final String ELEMENT = "bandwidth";
 
     /**
      * The name of the type argument.
@@ -41,7 +41,7 @@ public class BandwidthPacketExtension
      */
     public BandwidthPacketExtension()
     {
-        super(null, ELEMENT_NAME);
+        super(null, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/CandidatePacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/CandidatePacketExtension.java
@@ -26,7 +26,7 @@ public class CandidatePacketExtension extends AbstractPacketExtension
     /**
      * The name of the "candidate" element.
      */
-    public static final String ELEMENT_NAME = "candidate";
+    public static final String ELEMENT = "candidate";
 
     /**
      * The name of the "component" element.
@@ -108,7 +108,7 @@ public class CandidatePacketExtension extends AbstractPacketExtension
      */
     public CandidatePacketExtension()
     {
-        super(null, ELEMENT_NAME);
+        super(null, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/CoinPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/CoinPacketExtension.java
@@ -28,7 +28,7 @@ public class CoinPacketExtension
     /**
      * Name of the XML element representing the extension.
      */
-    public final static String ELEMENT_NAME = "conference-info";
+    public final static String ELEMENT = "conference-info";
 
     /**
      * Namespace.
@@ -46,7 +46,7 @@ public class CoinPacketExtension
      */
     public CoinPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -57,7 +57,7 @@ public class CoinPacketExtension
      */
     public CoinPacketExtension(boolean isFocus)
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
         setAttribute(ISFOCUS_ATTR_NAME, isFocus);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/ContentPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/ContentPacketExtension.java
@@ -30,7 +30,7 @@ public class ContentPacketExtension extends AbstractPacketExtension
     /**
      * The name of the "content" element.
      */
-    public static final String ELEMENT_NAME = "content";
+    public static final String ELEMENT = "content";
 
     /**
      * The name of the "creator" argument.
@@ -102,7 +102,7 @@ public class ContentPacketExtension extends AbstractPacketExtension
      */
     public ContentPacketExtension()
     {
-        super(null, ELEMENT_NAME);
+        super(null, ELEMENT);
     }
 
     /**
@@ -121,7 +121,7 @@ public class ContentPacketExtension extends AbstractPacketExtension
                                   String name,
                                   SendersEnum senders)
     {
-        super(null, ELEMENT_NAME);
+        super(null, ELEMENT);
         super.setAttribute(CREATOR_ATTR_NAME, creator);
         super.setAttribute(DISPOSITION_ATTR_NAME, disposition);
         super.setAttribute(NAME_ATTR_NAME, name);
@@ -139,7 +139,7 @@ public class ContentPacketExtension extends AbstractPacketExtension
      */
     public ContentPacketExtension(CreatorEnum creator, String name)
     {
-        super(null, ELEMENT_NAME);
+        super(null, ELEMENT);
         super.setAttribute(CREATOR_ATTR_NAME, creator);
         super.setAttribute(NAME_ATTR_NAME, name);
     }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/CryptoPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/CryptoPacketExtension.java
@@ -32,7 +32,7 @@ public class CryptoPacketExtension
     /**
      * The name of the "crypto" element.
      */
-    public static final String ELEMENT_NAME = "crypto";
+    public static final String ELEMENT = "crypto";
 
     /**
      * The namespace for the "crypto" element.
@@ -65,7 +65,7 @@ public class CryptoPacketExtension
      */
     public CryptoPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/DtlsFingerprintPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/DtlsFingerprintPacketExtension.java
@@ -31,7 +31,7 @@ public class DtlsFingerprintPacketExtension
      * The XML name of the <tt>fingerprint</tt> element defined by XEP-0320: Use
      * of DTLS-SRTP in Jingle Sessions.
      */
-    public static final String ELEMENT_NAME = "fingerprint";
+    public static final String ELEMENT = "fingerprint";
 
     /**
      * The XML name of the <tt>fingerprint</tt> element's attribute which
@@ -72,7 +72,7 @@ public class DtlsFingerprintPacketExtension
     /** Initializes a new <tt>DtlsFingerprintPacketExtension</tt> instance. */
     public DtlsFingerprintPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/EncryptionPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/EncryptionPacketExtension.java
@@ -38,7 +38,7 @@ public class EncryptionPacketExtension
     /**
      * The name of the "encryption" element.
      */
-    public static final String ELEMENT_NAME = "encryption";
+    public static final String ELEMENT = "encryption";
 
     /**
      * The name of the <tt>required</tt> attribute.
@@ -57,7 +57,7 @@ public class EncryptionPacketExtension
      */
     public EncryptionPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/GroupPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/GroupPacketExtension.java
@@ -34,7 +34,7 @@ public class GroupPacketExtension
     /**
      * The name of the "group" element.
      */
-    public static final String ELEMENT_NAME = "group";
+    public static final String ELEMENT = "group";
 
     /**
      * The namespace for the "group" element.
@@ -57,7 +57,7 @@ public class GroupPacketExtension
      */
     public GroupPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -154,7 +154,7 @@ public class GroupPacketExtension
             eventType = parser.next();
             elementName = parser.getName();
 
-            if (elementName.equals(ContentPacketExtension.ELEMENT_NAME))
+            if (elementName.equals(ContentPacketExtension.ELEMENT))
             {
                 ContentPacketExtension content
                     = contentProvider.parse(parser, xmlEnvironment);
@@ -162,7 +162,7 @@ public class GroupPacketExtension
             }
 
             if ((eventType == XmlPullParser.Event.END_ELEMENT)
-                && parser.getName().equals(ELEMENT_NAME))
+                && parser.getName().equals(ELEMENT))
             {
                 done = true;
             }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/IceUdpTransportPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/IceUdpTransportPacketExtension.java
@@ -40,7 +40,7 @@ public class IceUdpTransportPacketExtension
     /**
      * The name of the "transport" element.
      */
-    public static final String ELEMENT_NAME = "transport";
+    public static final String ELEMENT = "transport";
 
     /**
      * The name of the <tt>pwd</tt> ICE attribute.
@@ -73,7 +73,7 @@ public class IceUdpTransportPacketExtension
      */
     public IceUdpTransportPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -255,7 +255,7 @@ public class IceUdpTransportPacketExtension
     {
         for (ExtensionElement packetExtension : getChildExtensions())
         {
-            if (RtcpmuxPacketExtension.ELEMENT_NAME
+            if (RtcpmuxPacketExtension.ELEMENT
                     .equals(packetExtension.getElementName()))
                 return true;
         }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/InputEvtPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/InputEvtPacketExtension.java
@@ -28,7 +28,7 @@ public class InputEvtPacketExtension extends AbstractPacketExtension
     /**
      * Name of the XML element representing the extension.
      */
-    public final static String ELEMENT_NAME = "inputevt";
+    public final static String ELEMENT = "inputevt";
 
     /**
      * Namespace..
@@ -41,6 +41,6 @@ public class InputEvtPacketExtension extends AbstractPacketExtension
      */
     public InputEvtPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/JingleIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/JingleIQ.java
@@ -40,7 +40,7 @@ public class JingleIQ extends IQ
     /**
      * The name of the element that contains the jingle data.
      */
-    public static final String ELEMENT_NAME = "jingle";
+    public static final String ELEMENT = "jingle";
 
     /**
      * The name of the argument that contains the jingle action value.
@@ -122,7 +122,7 @@ public class JingleIQ extends IQ
      */
     public JingleIQ(JingleAction action, String sid)
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
         this.action = action;
         this.sid = sid;
     }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/JingleIQProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/JingleIQProvider.java
@@ -46,7 +46,7 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
     {
         //<description/> provider
         ProviderManager.addExtensionProvider(
-                RtpDescriptionPacketExtension.ELEMENT_NAME,
+                RtpDescriptionPacketExtension.ELEMENT,
                 RtpDescriptionPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <RtpDescriptionPacketExtension>(
@@ -54,7 +54,7 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         //<payload-type/> provider
         ProviderManager.addExtensionProvider(
-                PayloadTypePacketExtension.ELEMENT_NAME,
+                PayloadTypePacketExtension.ELEMENT,
                 RtpDescriptionPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <PayloadTypePacketExtension>(
@@ -62,7 +62,7 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         //<parameter/> provider
         ProviderManager.addExtensionProvider(
-                ParameterPacketExtension.ELEMENT_NAME,
+                ParameterPacketExtension.ELEMENT,
                 RtpDescriptionPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <ParameterPacketExtension>
@@ -70,7 +70,7 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         //<rtp-hdrext/> provider
         ProviderManager.addExtensionProvider(
-                RTPHdrExtPacketExtension.ELEMENT_NAME,
+                RTPHdrExtPacketExtension.ELEMENT,
                 RTPHdrExtPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <RTPHdrExtPacketExtension>
@@ -78,13 +78,13 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         // <sctpmap/> provider
         ProviderManager.addExtensionProvider(
-                SctpMapExtension.ELEMENT_NAME,
+                SctpMapExtension.ELEMENT,
                 SctpMapExtension.NAMESPACE,
                 new SctpMapExtensionProvider());
 
         //<encryption/> provider
         ProviderManager.addExtensionProvider(
-                EncryptionPacketExtension.ELEMENT_NAME,
+                EncryptionPacketExtension.ELEMENT,
                 RtpDescriptionPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <EncryptionPacketExtension>
@@ -92,7 +92,7 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         //<zrtp-hash/> provider
         ProviderManager.addExtensionProvider(
-                ZrtpHashPacketExtension.ELEMENT_NAME,
+                ZrtpHashPacketExtension.ELEMENT,
                 ZrtpHashPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <ZrtpHashPacketExtension>
@@ -100,7 +100,7 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         //<crypto/> provider
         ProviderManager.addExtensionProvider(
-                CryptoPacketExtension.ELEMENT_NAME,
+                CryptoPacketExtension.ELEMENT,
                 RtpDescriptionPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <CryptoPacketExtension>
@@ -108,14 +108,14 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         // <group/> provider
         ProviderManager.addExtensionProvider(
-                GroupPacketExtension.ELEMENT_NAME,
+                GroupPacketExtension.ELEMENT,
                 GroupPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <GroupPacketExtension>(GroupPacketExtension.class));
 
         //ice-udp transport
         ProviderManager.addExtensionProvider(
-                IceUdpTransportPacketExtension.ELEMENT_NAME,
+                IceUdpTransportPacketExtension.ELEMENT,
                 IceUdpTransportPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <IceUdpTransportPacketExtension>(
@@ -123,7 +123,7 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         //<raw-udp/> provider
         ProviderManager.addExtensionProvider(
-                RawUdpTransportPacketExtension.ELEMENT_NAME,
+                RawUdpTransportPacketExtension.ELEMENT,
                 RawUdpTransportPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <RawUdpTransportPacketExtension>(
@@ -131,7 +131,7 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         //ice-udp <candidate/> provider
         ProviderManager.addExtensionProvider(
-                CandidatePacketExtension.ELEMENT_NAME,
+                CandidatePacketExtension.ELEMENT,
                 IceUdpTransportPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <CandidatePacketExtension>(
@@ -139,7 +139,7 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         //raw-udp <candidate/> provider
         ProviderManager.addExtensionProvider(
-                CandidatePacketExtension.ELEMENT_NAME,
+                CandidatePacketExtension.ELEMENT,
                 RawUdpTransportPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <CandidatePacketExtension>(
@@ -147,7 +147,7 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         //ice-udp <remote-candidate/> provider
         ProviderManager.addExtensionProvider(
-                RemoteCandidatePacketExtension.ELEMENT_NAME,
+                RemoteCandidatePacketExtension.ELEMENT,
                 IceUdpTransportPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <RemoteCandidatePacketExtension>(
@@ -155,21 +155,21 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
 
         //inputevt <inputevt/> provider
         ProviderManager.addExtensionProvider(
-                InputEvtPacketExtension.ELEMENT_NAME,
+                InputEvtPacketExtension.ELEMENT,
                 InputEvtPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<InputEvtPacketExtension>(
                         InputEvtPacketExtension.class));
 
         //coin <conference-info/> provider
         ProviderManager.addExtensionProvider(
-                CoinPacketExtension.ELEMENT_NAME,
+                CoinPacketExtension.ELEMENT,
                 CoinPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<CoinPacketExtension>(
                         CoinPacketExtension.class));
 
         // DTLS-SRTP
         ProviderManager.addExtensionProvider(
-                DtlsFingerprintPacketExtension.ELEMENT_NAME,
+                DtlsFingerprintPacketExtension.ELEMENT,
                 DtlsFingerprintPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                         <DtlsFingerprintPacketExtension>(
@@ -180,47 +180,47 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
          * providers
          */
         ProviderManager.addExtensionProvider(
-                TransferPacketExtension.ELEMENT_NAME,
+                TransferPacketExtension.ELEMENT,
                 TransferPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<TransferPacketExtension>(
                         TransferPacketExtension.class));
         ProviderManager.addExtensionProvider(
-                TransferredPacketExtension.ELEMENT_NAME,
+                TransferredPacketExtension.ELEMENT,
                 TransferredPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<TransferredPacketExtension>(
                         TransferredPacketExtension.class));
 
         //conference description <callid/> provider
         ProviderManager.addExtensionProvider(
-                CallIdExtension.ELEMENT_NAME,
+                CallIdExtension.ELEMENT,
                 ConferenceDescriptionExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<CallIdExtension>(
                         CallIdExtension.class));
 
         //rtcp-fb
         ProviderManager.addExtensionProvider(
-                RtcpFbPacketExtension.ELEMENT_NAME,
+                RtcpFbPacketExtension.ELEMENT,
                 RtcpFbPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<RtcpFbPacketExtension>(
                         RtcpFbPacketExtension.class));
 
         //rtcp-mux
         ProviderManager.addExtensionProvider(
-                RtcpmuxPacketExtension.ELEMENT_NAME,
+                RtcpmuxPacketExtension.ELEMENT,
                 IceUdpTransportPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<RtcpmuxPacketExtension>(
                         RtcpmuxPacketExtension.class));
 
         //web-socket
         ProviderManager.addExtensionProvider(
-            WebSocketPacketExtension.ELEMENT_NAME,
+            WebSocketPacketExtension.ELEMENT,
             WebSocketPacketExtension.NAMESPACE,
             new DefaultPacketExtensionProvider<>(
                 WebSocketPacketExtension.class));
 
         //ssrcInfo
         ProviderManager.addExtensionProvider(
-                SSRCInfoPacketExtension.ELEMENT_NAME,
+                SSRCInfoPacketExtension.ELEMENT,
                 SSRCInfoPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider<SSRCInfoPacketExtension>(
                         SSRCInfoPacketExtension.class));
@@ -293,14 +293,14 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
             if (eventType == XmlPullParser.Event.START_ELEMENT)
             {
                 // <content/>
-                if (elementName.equals(ContentPacketExtension.ELEMENT_NAME))
+                if (elementName.equals(ContentPacketExtension.ELEMENT))
                 {
                     ContentPacketExtension content
                         = contentProvider.parse(parser);
                     jingleIQ.addContent(content);
                 }
                 // <reason/>
-                else if (elementName.equals(ReasonPacketExtension.ELEMENT_NAME))
+                else if (elementName.equals(ReasonPacketExtension.ELEMENT))
                 {
                     ReasonPacketExtension reason
                         = reasonProvider.parse(parser);
@@ -308,23 +308,23 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
                 }
                 // <transfer/>
                 else if (elementName.equals(
-                                TransferPacketExtension.ELEMENT_NAME)
+                                TransferPacketExtension.ELEMENT)
                         && namespace.equals(TransferPacketExtension.NAMESPACE))
                 {
                     jingleIQ.addExtension(transferProvider.parse(parser));
                 }
                 // <conference-info/>
-                else if (elementName.equals(CoinPacketExtension.ELEMENT_NAME))
+                else if (elementName.equals(CoinPacketExtension.ELEMENT))
                 {
                     jingleIQ.addExtension(coinProvider.parse(parser));
                 }
                 else if (elementName.equals(
-                        CallIdExtension.ELEMENT_NAME))
+                        CallIdExtension.ELEMENT))
                 {
                     jingleIQ.addExtension(callidProvider.parse(parser));
                 }
                 else if (elementName.equals(
-                        GroupPacketExtension.ELEMENT_NAME))
+                        GroupPacketExtension.ELEMENT))
                 {
                     jingleIQ.addExtension(
                         GroupPacketExtension.parseExtension(parser, xmlEnvironment));
@@ -359,7 +359,7 @@ public class JingleIQProvider extends IQProvider<JingleIQ>
             }
 
             if ((eventType == XmlPullParser.Event.END_ELEMENT)
-                    && parser.getName().equals(JingleIQ.ELEMENT_NAME))
+                    && parser.getName().equals(JingleIQ.ELEMENT))
             {
                     done = true;
             }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/ParameterPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/ParameterPacketExtension.java
@@ -27,7 +27,7 @@ public class ParameterPacketExtension extends AbstractPacketExtension
     /**
      * The name of the "parameter" element.
      */
-    public static final String ELEMENT_NAME = "parameter";
+    public static final String ELEMENT = "parameter";
 
     /**
      * The name of the <tt>name</tt> parameter in the <tt>parameter</tt>
@@ -46,7 +46,7 @@ public class ParameterPacketExtension extends AbstractPacketExtension
      */
     public ParameterPacketExtension()
     {
-        super(null, ELEMENT_NAME);
+        super(null, ELEMENT);
     }
 
     /**
@@ -55,7 +55,7 @@ public class ParameterPacketExtension extends AbstractPacketExtension
      */
     public ParameterPacketExtension(String name, String value)
     {
-        super(null, ELEMENT_NAME);
+        super(null, ELEMENT);
 
         setName(name);
         setValue(value);

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/PayloadTypePacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/PayloadTypePacketExtension.java
@@ -29,7 +29,7 @@ public class PayloadTypePacketExtension extends AbstractPacketExtension
     /**
      * The name of the "payload-type" element.
      */
-    public static final String ELEMENT_NAME = "payload-type";
+    public static final String ELEMENT = "payload-type";
 
     /**
      * The namespace of the "payload-type" element
@@ -95,7 +95,7 @@ public class PayloadTypePacketExtension extends AbstractPacketExtension
      */
     public PayloadTypePacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/RTPHdrExtPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/RTPHdrExtPacketExtension.java
@@ -44,7 +44,7 @@ public class RTPHdrExtPacketExtension
     /**
      * The name of the "candidate" element.
      */
-    public static final String ELEMENT_NAME = "rtp-hdrext";
+    public static final String ELEMENT = "rtp-hdrext";
 
     /**
      * The name of the ID attribute.
@@ -72,7 +72,7 @@ public class RTPHdrExtPacketExtension
      */
     public RTPHdrExtPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/RawUdpTransportPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/RawUdpTransportPacketExtension.java
@@ -38,14 +38,14 @@ public class RawUdpTransportPacketExtension
     /**
      * The name of the "transport" element.
      */
-    public static final String ELEMENT_NAME = "transport";
+    public static final String ELEMENT = "transport";
 
     /**
      * Creates a new {@link RawUdpTransportPacketExtension} instance.
      */
     public RawUdpTransportPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/ReasonPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/ReasonPacketExtension.java
@@ -38,12 +38,12 @@ public class ReasonPacketExtension
     /**
      * The name of the "content" element.
      */
-    public static final String ELEMENT_NAME = "reason";
+    public static final String ELEMENT = "reason";
 
     /**
      * The name of the text element.
      */
-    public static final String TEXT_ELEMENT_NAME = "text";
+    public static final String TEXT_ELEMENT = "text";
 
     /**
      * The reason that this packet extension is transporting.
@@ -154,7 +154,7 @@ public class ReasonPacketExtension
      */
     public String getElementName()
     {
-        return ELEMENT_NAME;
+        return ELEMENT;
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/ReasonProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/ReasonProvider.java
@@ -72,7 +72,7 @@ public class ReasonProvider extends ExtensionElementProvider<ReasonPacketExtensi
                     reason = Reason.parseString(elementName);
                 }
                 else if (elementName.equals(
-                                ReasonPacketExtension.TEXT_ELEMENT_NAME))
+                                ReasonPacketExtension.TEXT_ELEMENT))
                 {
                     text = parseText(parser);
                 }
@@ -83,7 +83,7 @@ public class ReasonProvider extends ExtensionElementProvider<ReasonPacketExtensi
             }
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
-                if (parser.getName().equals(ReasonPacketExtension.ELEMENT_NAME))
+                if (parser.getName().equals(ReasonPacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/RedirectPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/RedirectPacketExtension.java
@@ -28,7 +28,7 @@ public class RedirectPacketExtension
     /**
      * The name of the "redirect" element.
      */
-    public static final String ELEMENT_NAME = "redirect";
+    public static final String ELEMENT = "redirect";
 
     /**
      * The namespace.
@@ -45,7 +45,7 @@ public class RedirectPacketExtension
      */
     public RedirectPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/RedirectProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/RedirectProvider.java
@@ -65,7 +65,7 @@ public class RedirectProvider
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
                 if (parser.getName().equals(
-                    RedirectPacketExtension.ELEMENT_NAME))
+                    RedirectPacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/RemoteCandidatePacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/RemoteCandidatePacketExtension.java
@@ -25,13 +25,13 @@ public class RemoteCandidatePacketExtension extends CandidatePacketExtension
     /**
      * The name of the "candidate" element.
      */
-    public static final String ELEMENT_NAME = "remote-candidate";
+    public static final String ELEMENT = "remote-candidate";
 
     /**
      * Creates a new {@link CandidatePacketExtension}
      */
     public RemoteCandidatePacketExtension()
     {
-        super(ELEMENT_NAME);
+        super(ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/RtcpFbPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/RtcpFbPacketExtension.java
@@ -34,7 +34,7 @@ public class RtcpFbPacketExtension
     /**
      * The name of the RTCP feedback element.
      */
-    public static final String ELEMENT_NAME = "rtcp-fb";
+    public static final String ELEMENT = "rtcp-fb";
 
     /**
      * The name the attribute that holds the feedback type.
@@ -51,7 +51,7 @@ public class RtcpFbPacketExtension
      */
     public RtcpFbPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/RtcpmuxPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/RtcpmuxPacketExtension.java
@@ -27,14 +27,14 @@ public class RtcpmuxPacketExtension
     /**
      * The name of the "encryption" element.
      */
-    public static final String ELEMENT_NAME = "rtcp-mux";
+    public static final String ELEMENT = "rtcp-mux";
 
     /**
      * Creates a new instance of <tt>RtcpmuxPacketExtension</tt>.
      */
     public RtcpmuxPacketExtension()
     {
-        super(null, ELEMENT_NAME);
+        super(null, ELEMENT);
     }
 }
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/RtpDescriptionPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/RtpDescriptionPacketExtension.java
@@ -37,7 +37,7 @@ public class RtpDescriptionPacketExtension
     /**
      * The name of the "description" element.
      */
-    public static final String ELEMENT_NAME = "description";
+    public static final String ELEMENT = "description";
 
     /**
      * The name of the <tt>media</tt> description argument.
@@ -83,7 +83,7 @@ public class RtpDescriptionPacketExtension
      */
     public RtpDescriptionPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -94,7 +94,7 @@ public class RtpDescriptionPacketExtension
      */
     public RtpDescriptionPacketExtension(String namespace)
     {
-        super(namespace, ELEMENT_NAME);
+        super(namespace, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/SctpMapExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/SctpMapExtension.java
@@ -31,7 +31,7 @@ public class SctpMapExtension
     /**
      * The name of the "sctpmap" element.
      */
-    public static final String ELEMENT_NAME = "sctpmap";
+    public static final String ELEMENT = "sctpmap";
 
     /**
      * The namespace for the "sctpmap" element.
@@ -76,7 +76,7 @@ public class SctpMapExtension
     @Override
     public String getElementName()
     {
-        return ELEMENT_NAME;
+        return ELEMENT;
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/SctpMapExtensionProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/SctpMapExtensionProvider.java
@@ -42,7 +42,7 @@ public class SctpMapExtensionProvider
     {
         SctpMapExtension result = new SctpMapExtension();
 
-        if (parser.getName().equals(SctpMapExtension.ELEMENT_NAME)
+        if (parser.getName().equals(SctpMapExtension.ELEMENT)
             && parser.getNamespace().equals(SctpMapExtension.NAMESPACE))
         {
             result.setPort(Integer.parseInt(parser.getAttributeValue(null,

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/SourceGroupPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/SourceGroupPacketExtension.java
@@ -33,7 +33,7 @@ public class SourceGroupPacketExtension
     /**
      * The name of the "ssrc-group" element.
      */
-    public static final String ELEMENT_NAME = "ssrc-group";
+    public static final String ELEMENT = "ssrc-group";
 
     /**
      * The namespace for the "ssrc-group" element.
@@ -80,7 +80,7 @@ public class SourceGroupPacketExtension
      */
     public SourceGroupPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     public SourceGroupPacketExtension(String elementName)

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/SourceRidGroupPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/SourceRidGroupPacketExtension.java
@@ -26,10 +26,10 @@ public class SourceRidGroupPacketExtension extends SourceGroupPacketExtension
     /**
      * The name of the "rid-group" element.
      */
-    public static final String ELEMENT_NAME = "rid-group";
+    public static final String ELEMENT = "rid-group";
 
     public SourceRidGroupPacketExtension()
     {
-        super(ELEMENT_NAME);
+        super(ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/TransferPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/TransferPacketExtension.java
@@ -32,7 +32,7 @@ public class TransferPacketExtension
     /**
      * The name of the "transfer" element.
      */
-    public static final String ELEMENT_NAME = "transfer";
+    public static final String ELEMENT = "transfer";
 
     /**
      * The name of the "from" attribute of the "transfer" element.
@@ -59,7 +59,7 @@ public class TransferPacketExtension
      */
     public TransferPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/TransferredPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/TransferredPacketExtension.java
@@ -29,7 +29,7 @@ public class TransferredPacketExtension
     /**
      * The name of the "transfer" element.
      */
-    public static final String ELEMENT_NAME = "transferred";
+    public static final String ELEMENT = "transferred";
 
     /**
      * The namespace of the "transfer" element.
@@ -41,6 +41,6 @@ public class TransferredPacketExtension
      */
     public TransferredPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/ZrtpHashPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/ZrtpHashPacketExtension.java
@@ -28,7 +28,7 @@ public class ZrtpHashPacketExtension extends AbstractPacketExtension
     /**
      * The name of the "zrtp-hash" element.
      */
-    public static final String ELEMENT_NAME = "zrtp-hash";
+    public static final String ELEMENT = "zrtp-hash";
 
     /**
      * The namespace for the "zrtp-hash" element.
@@ -46,7 +46,7 @@ public class ZrtpHashPacketExtension extends AbstractPacketExtension
      */
     public ZrtpHashPacketExtension()
     {
-        super (NAMESPACE, ELEMENT_NAME);
+        super (NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/JingleInfoQueryIQ.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/JingleInfoQueryIQ.java
@@ -34,11 +34,11 @@ public class JingleInfoQueryIQ
     /**
      * The element name.
      */
-    public static final String ELEMENT_NAME = "query";
+    public static final String ELEMENT = "query";
 
     public JingleInfoQueryIQ()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/JingleInfoQueryIQProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/JingleInfoQueryIQProvider.java
@@ -52,7 +52,7 @@ public class JingleInfoQueryIQProvider
     public JingleInfoQueryIQProvider()
     {
         ProviderManager.addExtensionProvider(
-                ServerPacketExtension.ELEMENT_NAME,
+                ServerPacketExtension.ELEMENT,
                 ServerPacketExtension.NAMESPACE,
                 new DefaultPacketExtensionProvider
                     <ServerPacketExtension>(ServerPacketExtension.class));
@@ -80,18 +80,18 @@ public class JingleInfoQueryIQProvider
 
             if (eventType == XmlPullParser.Event.START_ELEMENT)
             {
-                if (elementName.equals(StunPacketExtension.ELEMENT_NAME))
+                if (elementName.equals(StunPacketExtension.ELEMENT))
                 {
                     iq.addExtension((StunPacketExtension)stunProvider.parse(parser));
                 }
-                else if (elementName.equals(RelayPacketExtension.ELEMENT_NAME))
+                else if (elementName.equals(RelayPacketExtension.ELEMENT))
                 {
                     iq.addExtension((RelayPacketExtension)relayProvider.parse(parser));
                 }
             }
             if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
-                if (parser.getName().equals(JingleInfoQueryIQ.ELEMENT_NAME))
+                if (parser.getName().equals(JingleInfoQueryIQ.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/RelayPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/RelayPacketExtension.java
@@ -36,7 +36,7 @@ public class RelayPacketExtension
     /**
      * The element name.
      */
-    public static final String ELEMENT_NAME = "relay";
+    public static final String ELEMENT = "relay";
 
     /**
      * The token.
@@ -48,7 +48,7 @@ public class RelayPacketExtension
      */
     public RelayPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -81,7 +81,7 @@ public class RelayPacketExtension
     {
         XmlStringBuilder xml = new XmlStringBuilder();
 
-        xml.halfOpenElement(ELEMENT_NAME);
+        xml.halfOpenElement(ELEMENT);
 
         if (token != null)
         {
@@ -93,7 +93,7 @@ public class RelayPacketExtension
             xml.optAppend(pe);
         }
 
-        xml.closeElement(ELEMENT_NAME);
+        xml.closeElement(ELEMENT);
 
         return xml.toString();
     }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/RelayProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/RelayProvider.java
@@ -61,11 +61,11 @@ public class RelayProvider
 
             if (eventType == XmlPullParser.Event.START_ELEMENT)
             {
-                if (elementName.equals(ServerPacketExtension.ELEMENT_NAME))
+                if (elementName.equals(ServerPacketExtension.ELEMENT))
                 {
                     ExtensionElementProvider provider = (ExtensionElementProvider)
                         ProviderManager.getExtensionProvider(
-                                ServerPacketExtension.ELEMENT_NAME,
+                                ServerPacketExtension.ELEMENT,
                                 ServerPacketExtension.NAMESPACE);
                     ExtensionElement childExtension =
                             (ExtensionElement) provider.parse(parser);
@@ -79,7 +79,7 @@ public class RelayProvider
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
                 if (parser.getName().equals(
-                        RelayPacketExtension.ELEMENT_NAME))
+                        RelayPacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/ServerPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/ServerPacketExtension.java
@@ -33,7 +33,7 @@ public class ServerPacketExtension
     /**
      * The element name.
      */
-    public static final String ELEMENT_NAME = "server";
+    public static final String ELEMENT = "server";
 
     /**
      * Host attribute name.
@@ -60,7 +60,7 @@ public class ServerPacketExtension
      */
     public ServerPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/StunPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/StunPacketExtension.java
@@ -33,13 +33,13 @@ public class StunPacketExtension
     /**
      * The element name.
      */
-    public static final String ELEMENT_NAME = "stun";
+    public static final String ELEMENT = "stun";
 
     /**
      * Constructor.
      */
     public StunPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/StunProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingleinfo/StunProvider.java
@@ -61,11 +61,11 @@ public class StunProvider
 
             if (eventType == XmlPullParser.Event.START_ELEMENT)
             {
-                if (elementName.equals(ServerPacketExtension.ELEMENT_NAME))
+                if (elementName.equals(ServerPacketExtension.ELEMENT))
                 {
                     ExtensionElementProvider provider = (ExtensionElementProvider)
                         ProviderManager.getExtensionProvider(
-                                ServerPacketExtension.ELEMENT_NAME,
+                                ServerPacketExtension.ELEMENT,
                                 ServerPacketExtension.NAMESPACE);
                     ExtensionElement childExtension =
                             (ExtensionElement) provider.parse(parser);
@@ -75,7 +75,7 @@ public class StunProvider
             else if (eventType == XmlPullParser.Event.END_ELEMENT)
             {
                 if (parser.getName().equals(
-                        StunPacketExtension.ELEMENT_NAME))
+                        StunPacketExtension.ELEMENT))
                 {
                     done = true;
                 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/AudioMutedExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/AudioMutedExtension.java
@@ -35,14 +35,14 @@ public class AudioMutedExtension
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "audiomuted";
+    public static final String ELEMENT = "audiomuted";
 
     /**
      * Creates new instance of <tt>AudioMutedExtension</tt>.
      */
     public AudioMutedExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/AvatarIdPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/AvatarIdPacketExtension.java
@@ -32,12 +32,13 @@ public class AvatarIdPacketExtension
     /**
      * The namespace (xmlns attribute) of this avatar-id presence element
      */
-    public static final String NAME_SPACE = "jabber:client";
+    public static final String NAMESPACE = "jabber:client";
 
     /**
      * The element name of this avatar-id presence element
+     *
      */
-    public static final String ELEMENT_NAME = "avatar-id";
+    public static final String ELEMENT = "avatar-id";
 
     /**
      * Default constructor.
@@ -46,7 +47,7 @@ public class AvatarIdPacketExtension
      */
     public AvatarIdPacketExtension()
     {
-        super(NAME_SPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -57,7 +58,7 @@ public class AvatarIdPacketExtension
      */
     public AvatarIdPacketExtension(String avatarId)
     {
-        super(NAME_SPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
 
         setText(avatarId);
     }

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/AvatarUrl.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/AvatarUrl.java
@@ -34,7 +34,7 @@ public class AvatarUrl
 {
     public static final String NAMESPACE = "jabber:client";
 
-    public static final String ELEMENT_NAME = "avatar-url";
+    public static final String ELEMENT = "avatar-url";
 
     private String avatarUrl = null;
 
@@ -71,7 +71,7 @@ public class AvatarUrl
      */
     public String getElementName()
     {
-        return ELEMENT_NAME;
+        return ELEMENT;
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/BridgeNotAvailablePacketExt.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/BridgeNotAvailablePacketExt.java
@@ -27,12 +27,12 @@ import org.jitsi.xmpp.extensions.*;
 public class BridgeNotAvailablePacketExt
     extends AbstractPacketExtension
 {
-    public final static String ELEMENT_NAME = "bridgeNotAvailable";
+    public final static String ELEMENT = "bridgeNotAvailable";
 
     public final static String NAMESPACE = ConferenceIq.NAMESPACE;
 
     public BridgeNotAvailablePacketExt()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/BridgeSessionPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/BridgeSessionPacketExtension.java
@@ -30,7 +30,7 @@ public class BridgeSessionPacketExtension
     /**
      * The name of the {@code bridge-session} element.
      */
-    public static final String ELEMENT_NAME = "bridge-session";
+    public static final String ELEMENT = "bridge-session";
 
     /**
      * The name of the attribute which carries the bridge session's ID.
@@ -59,7 +59,7 @@ public class BridgeSessionPacketExtension
      */
     public BridgeSessionPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     public BridgeSessionPacketExtension(String id, String region)

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ComponentVersionsExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ComponentVersionsExtension.java
@@ -17,6 +17,8 @@ package org.jitsi.xmpp.extensions.jitsimeet;
 
 import org.jitsi.xmpp.extensions.*;
 
+import javax.xml.namespace.*;
+
 /**
  * The packet extension is used by Jicofo to broadcast versions of all video
  * conferencing system components. This packets extension is added to jicofo's
@@ -31,13 +33,13 @@ public class ComponentVersionsExtension
     /**
      * The XML element name of {@link ComponentVersionsExtension}.
      */
-    public static final String ELEMENT_NAME = "versions";
+    public static final String ELEMENT = "versions";
 
     /**
      * The name of XML sub-elements which carry the info about particular
      * component's version.
      */
-    public static final String COMPONENT_ELEMENT_NAME = "component";
+    public static final String COMPONENT_ELEMENT = "component";
 
     /**
      * Constant for {@link Component} name used to signal the version of
@@ -68,7 +70,7 @@ public class ComponentVersionsExtension
      */
     public ComponentVersionsExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -94,7 +96,7 @@ public class ComponentVersionsExtension
      * of the component is carried in name attribute and the version string is
      * the text value.
      */
-    public class Component
+    public static class Component
         extends AbstractPacketExtension
     {
         /**
@@ -103,11 +105,16 @@ public class ComponentVersionsExtension
         private final String NAME_ATTR_NAME = "name";
 
         /**
+         * The qualified name of the element.
+         */
+        public static final QName QNAME = new QName(NAMESPACE, COMPONENT_ELEMENT);
+
+        /**
          * Creates new instance of {@link Component} packet extension.
          */
         public Component()
         {
-            super(NAMESPACE, COMPONENT_ELEMENT_NAME);
+            super(NAMESPACE, COMPONENT_ELEMENT);
         }
 
         /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ConferenceIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ConferenceIq.java
@@ -16,9 +16,11 @@
 package org.jitsi.xmpp.extensions.jitsimeet;
 
 import org.jitsi.xmpp.extensions.*;
+import org.jitsi.xmpp.extensions.rayo.*;
 import org.jivesoftware.smack.packet.*;
 import org.jxmpp.jid.*;
 
+import javax.xml.namespace.*;
 import java.util.*;
 
 /**
@@ -40,7 +42,7 @@ public class ConferenceIq
     /**
      * XML element name for the <tt>ConferenceIq</tt>.
      */
-    public static final String ELEMENT_NAME = "conference";
+    public static final String ELEMENT = "conference";
 
     /**
      * The name of the attribute that stores the name of multi user chat room
@@ -112,7 +114,7 @@ public class ConferenceIq
      */
     public ConferenceIq()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     @Override
@@ -202,7 +204,7 @@ public class ConferenceIq
     public List<Property> getProperties()
     {
         return (List)getExtensions(
-                Property.ELEMENT_NAME,
+                Property.ELEMENT,
                 ConferenceIq.NAMESPACE);
     }
 
@@ -294,7 +296,12 @@ public class ConferenceIq
         /**
          * The name of property XML element.
          */
-        public static final String ELEMENT_NAME = "property";
+        public static final String ELEMENT = "property";
+
+        /**
+         * Qualified name of element.
+         */
+        public static final QName QNAME = new QName(ConferenceIq.NAMESPACE, ELEMENT);
 
         /**
          * The name of 'name' property attribute.
@@ -311,7 +318,7 @@ public class ConferenceIq
          */
         public Property()
         {
-            super(ConferenceIq.NAMESPACE, ELEMENT_NAME);
+            super(ConferenceIq.NAMESPACE, ELEMENT);
         }
 
         /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ConferenceIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ConferenceIqProvider.java
@@ -46,7 +46,7 @@ public class ConferenceIqProvider
     {
         // <conference>
         ProviderManager.addIQProvider(
-            ConferenceIq.ELEMENT_NAME, ConferenceIq.NAMESPACE, this);
+            ConferenceIq.ELEMENT, ConferenceIq.NAMESPACE, this);
     }
 
     /**
@@ -67,7 +67,7 @@ public class ConferenceIqProvider
         String rootElement = parser.getName();
 
         ConferenceIq iq;
-        if (ConferenceIq.ELEMENT_NAME.equals(rootElement))
+        if (ConferenceIq.ELEMENT.equals(rootElement))
         {
             iq = new ConferenceIq();
             EntityBareJid room
@@ -130,7 +130,7 @@ public class ConferenceIqProvider
                     {
                         done = true;
                     }
-                    else if (ConferenceIq.Property.ELEMENT_NAME.equals(name))
+                    else if (ConferenceIq.Property.ELEMENT.equals(name))
                     {
                         if (property != null)
                         {
@@ -145,7 +145,7 @@ public class ConferenceIqProvider
                 {
                     String name = parser.getName();
 
-                    if (ConferenceIq.Property.ELEMENT_NAME.equals(name))
+                    if (ConferenceIq.Property.ELEMENT.equals(name))
                     {
                         property = new ConferenceIq.Property();
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ConferenceProperties.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ConferenceProperties.java
@@ -17,6 +17,7 @@ package org.jitsi.xmpp.extensions.jitsimeet;
 
 import org.jitsi.xmpp.extensions.*;
 
+import javax.xml.namespace.*;
 import java.util.*;
 
 /**
@@ -38,7 +39,7 @@ public class ConferenceProperties
     /**
      * The XML name of the conference-properties element.
      */
-    public static final String ELEMENT_NAME = "conference-properties";
+    public static final String ELEMENT = "conference-properties";
 
     /**
      * The property key used for the conference creation timestamp (in
@@ -88,7 +89,7 @@ public class ConferenceProperties
      */
     public ConferenceProperties()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -155,7 +156,12 @@ public class ConferenceProperties
         /**
          * The XML name of the conference property element.
          */
-        public static final String ELEMENT_NAME = "property";
+        public static final String ELEMENT = "property";
+
+        /**
+         * The qualified name of the conference property element.
+         */
+        public static final QName QNAME = new QName(NAMESPACE, ELEMENT);
 
         /**
          * The name of the "key" attribute.
@@ -174,7 +180,7 @@ public class ConferenceProperties
          */
         public ConferenceProperty()
         {
-            super(NAMESPACE, ELEMENT_NAME);
+            super(NAMESPACE, ELEMENT);
         }
 
         /**
@@ -185,7 +191,7 @@ public class ConferenceProperties
          */
         public ConferenceProperty(String key, String value)
         {
-            super(NAMESPACE, ELEMENT_NAME);
+            super(NAMESPACE, ELEMENT);
 
             setAttribute(KEY_ATTR_NAME, key);
             setAttribute(VALUE_ATTR_NAME, value);

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/Email.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/Email.java
@@ -33,7 +33,7 @@ public class Email
 {
     public static final String NAMESPACE = "jabber:client";
 
-    public static final String ELEMENT_NAME = "email";
+    public static final String ELEMENT = "email";
 
     private String address = null;
 
@@ -68,7 +68,7 @@ public class Email
      */
     public String getElementName()
     {
-        return ELEMENT_NAME;
+        return ELEMENT;
     }
 
     /**
@@ -87,7 +87,7 @@ public class Email
     public String toXML(XmlEnvironment enclosingNamespace)
     {
         return new XmlStringBuilder()
-            .element(ELEMENT_NAME, getAddress())
+            .element(ELEMENT, getAddress())
             .toString();
     }
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/EtherpadPacketExt.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/EtherpadPacketExt.java
@@ -34,14 +34,14 @@ public class EtherpadPacketExt
     /**
      * XML element name of this packets extension.
      */
-    public static final String ELEMENT_NAME = "etherpad";
+    public static final String ELEMENT = "etherpad";
 
     /**
      * Creates new instance of <tt>EtherpadPacketExt</tt>.
      */
     public EtherpadPacketExt()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/FeatureExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/FeatureExtension.java
@@ -20,11 +20,11 @@ import org.jitsi.xmpp.extensions.*;
 public class FeatureExtension extends AbstractPacketExtension
 {
     public static final String NAMESPACE = "jabber:client";
-    public static final String ELEMENT_NAME = "feature";
+    public static final String ELEMENT = "feature";
 
     public FeatureExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     public String getVar()

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/FeaturesExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/FeaturesExtension.java
@@ -22,11 +22,11 @@ import java.util.*;
 public class FeaturesExtension extends AbstractPacketExtension
 {
     public static final String NAMESPACE = "jabber:client";
-    public static final String ELEMENT_NAME = "features";
+    public static final String ELEMENT = "features";
 
     public FeaturesExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     public List<FeatureExtension> getFeatureExtensions()

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/IceStatePacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/IceStatePacketExtension.java
@@ -34,13 +34,13 @@ public class IceStatePacketExtension
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "ice-state";
+    public static final String ELEMENT = "ice-state";
 
     /**
      * Creates new instance of <tt>IceStatePacketExtension</tt>
      */
     public IceStatePacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/IdentityPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/IdentityPacketExtension.java
@@ -56,38 +56,38 @@ public class IdentityPacketExtension
     /**
      * The namespace (xmlns attribute) of this identity presence element
      */
-    public static final String NAME_SPACE = "jabber:client";
+    public static final String NAMESPACE = "jabber:client";
 
     /**
      * The element name of this identity presence element
      */
-    public static final String ELEMENT_NAME = "identity";
+    public static final String ELEMENT = "identity";
 
     /**
      * The child element of this identity storing information about the user
      */
-    public static final String USER_ELEMENT_NAME = "user";
+    public static final String USER_ELEMENT = "user";
 
     /**
      * The child element of this identity storing information about the group
      * id
      */
-    public static final String GROUP_ELEMENT_NAME = "group";
+    public static final String GROUP_ELEMENT = "group";
 
     /**
      * The child element of the user element storing the user id
      */
-    public static final String USER_ID_ELEMENT_NAME = "id";
+    public static final String USER_ID_ELEMENT = "id";
 
     /**
      * The child element of the user element storing the user avatar-url
      */
-    public static final String USER_AVATAR_URL_ELEMENT_NAME = "avatar";
+    public static final String USER_AVATAR_URL_ELEMENT = "avatar";
 
     /**
      * The child element of the user element storing the user name
      */
-    public static final String USER_NAME_ELEMENT_NAME = "name";
+    public static final String USER_NAME_ELEMENT = "name";
 
     /**
      * The unique ID belonging to the user
@@ -135,7 +135,7 @@ public class IdentityPacketExtension
     @Override
     public String getNamespace()
     {
-        return NAME_SPACE;
+        return NAMESPACE;
     }
 
     /**
@@ -144,7 +144,7 @@ public class IdentityPacketExtension
     @Override
     public String getElementName()
     {
-        return ELEMENT_NAME;
+        return ELEMENT;
     }
 
     /**
@@ -156,23 +156,23 @@ public class IdentityPacketExtension
         XmlStringBuilder xml = new XmlStringBuilder();
 
         // begin identity
-        xml.openElement(ELEMENT_NAME);
+        xml.openElement(ELEMENT);
 
         //begin user
-        xml.openElement(USER_ELEMENT_NAME);
+        xml.openElement(USER_ELEMENT);
 
-        xml.element(USER_ID_ELEMENT_NAME, getUserId());
-        xml.element(USER_NAME_ELEMENT_NAME, getUserName());
-        xml.element(USER_AVATAR_URL_ELEMENT_NAME, getUserAvatarUrl());
+        xml.element(USER_ID_ELEMENT, getUserId());
+        xml.element(USER_NAME_ELEMENT, getUserName());
+        xml.element(USER_AVATAR_URL_ELEMENT, getUserAvatarUrl());
 
         // end user
-        xml.closeElement(USER_ELEMENT_NAME);
+        xml.closeElement(USER_ELEMENT);
 
         // begin and end group
-        xml.element(GROUP_ELEMENT_NAME, getGroupId());
+        xml.element(GROUP_ELEMENT, getGroupId());
 
         // end identity
-        xml.closeElement(ELEMENT_NAME);
+        xml.closeElement(ELEMENT);
 
         return xml.toString();
     }
@@ -234,11 +234,11 @@ public class IdentityPacketExtension
         {
             String currentTag = parser.getName();
 
-            if (!NAME_SPACE.equals(parser.getNamespace()))
+            if (!NAMESPACE.equals(parser.getNamespace()))
             {
                 return null;
             }
-            else if (!ELEMENT_NAME.equals(currentTag))
+            else if (!ELEMENT.equals(currentTag))
             {
                 return null;
             }
@@ -262,16 +262,16 @@ public class IdentityPacketExtension
                     {
                         switch (currentTag)
                         {
-                            case USER_AVATAR_URL_ELEMENT_NAME:
+                            case USER_AVATAR_URL_ELEMENT:
                                 userAvatarUrl = parser.getText();
                                 break;
-                            case USER_ID_ELEMENT_NAME:
+                            case USER_ID_ELEMENT:
                                 userId = parser.getText();
                                 break;
-                            case USER_NAME_ELEMENT_NAME:
+                            case USER_NAME_ELEMENT:
                                 userName = parser.getText();
                                 break;
-                            case GROUP_ELEMENT_NAME:
+                            case GROUP_ELEMENT:
                                 groupId = parser.getText();
                                 break;
                             default:
@@ -283,7 +283,7 @@ public class IdentityPacketExtension
                         currentTag = parser.getName();
                     }
                 }
-                while (!ELEMENT_NAME.equals(currentTag));
+                while (!ELEMENT.equals(currentTag));
             }
             catch (XmlPullParserException | IOException e)
             {

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/JsonMessageExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/JsonMessageExtension.java
@@ -36,14 +36,14 @@ public class JsonMessageExtension
     /**
      * The element name of this json-message packet.
      */
-    public static final String ELEMENT_NAME = "json-message";
+    public static final String ELEMENT = "json-message";
 
     /**
      * Creates a {@link JsonMessageExtension} instance.
      */
     public JsonMessageExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -54,7 +54,7 @@ public class JsonMessageExtension
      */
     public JsonMessageExtension(String json)
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
 
         setText(json);
     }

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/LoginUrlIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/LoginUrlIq.java
@@ -33,7 +33,7 @@ public class LoginUrlIq
 {
     public static final String NAMESPACE = ConferenceIq.NAMESPACE;
 
-    public static final String ELEMENT_NAME = "login-url";
+    public static final String ELEMENT = "login-url";
 
     /**
      * The name of the attribute that holds authentication URL value.
@@ -86,7 +86,7 @@ public class LoginUrlIq
      */
     public LoginUrlIq()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     @Override

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/LoginUrlIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/LoginUrlIqProvider.java
@@ -42,7 +42,7 @@ public class LoginUrlIqProvider
     {
         // <auth-url>
         ProviderManager.addIQProvider(
-            LoginUrlIq.ELEMENT_NAME, LoginUrlIq.NAMESPACE, this);
+            LoginUrlIq.ELEMENT, LoginUrlIq.NAMESPACE, this);
     }
 
     /**
@@ -63,7 +63,7 @@ public class LoginUrlIqProvider
         String rootElement = parser.getName();
 
         LoginUrlIq authUrlIQ;
-        if (LoginUrlIq.ELEMENT_NAME.equals(rootElement))
+        if (LoginUrlIq.ELEMENT.equals(rootElement))
         {
             authUrlIQ = new LoginUrlIq();
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/LogoutIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/LogoutIq.java
@@ -33,7 +33,7 @@ public class LogoutIq
     /**
      * XML element name of logout IQ.
      */
-    public static final String ELEMENT_NAME = "logout";
+    public static final String ELEMENT = "logout";
 
     /**
      * XML namespace of logout IQ.
@@ -67,7 +67,7 @@ public class LogoutIq
      */
     public LogoutIq()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/LogoutIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/LogoutIqProvider.java
@@ -40,7 +40,7 @@ public class LogoutIqProvider
     {
         //<logout>
         ProviderManager.addIQProvider(
-            LogoutIq.ELEMENT_NAME, LogoutIq.NAMESPACE, this);
+            LogoutIq.ELEMENT, LogoutIq.NAMESPACE, this);
     }
 
     /**
@@ -60,7 +60,7 @@ public class LogoutIqProvider
 
         String rootElement = parser.getName();
         LogoutIq logoutIq;
-        if (LogoutIq.ELEMENT_NAME.endsWith(rootElement))
+        if (LogoutIq.ELEMENT.endsWith(rootElement))
         {
             logoutIq = new LogoutIq();
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteIq.java
@@ -35,7 +35,7 @@ public class MuteIq
     /**
      * XML element name of mute packet extension.
      */
-    public static final String ELEMENT_NAME = "mute";
+    public static final String ELEMENT = "mute";
 
     /**
      * Attribute name of "jid".
@@ -67,7 +67,7 @@ public class MuteIq
      */
     public MuteIq()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     @Override

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteIqProvider.java
@@ -39,7 +39,7 @@ public class MuteIqProvider
     public static void registerMuteIqProvider()
     {
         ProviderManager.addIQProvider(
-            MuteIq.ELEMENT_NAME,
+            MuteIq.ELEMENT,
             MuteIq.NAMESPACE,
             new MuteIqProvider());
     }
@@ -63,7 +63,7 @@ public class MuteIqProvider
 
         MuteIq iq;
 
-        if (MuteIq.ELEMENT_NAME.equals(rootElement))
+        if (MuteIq.ELEMENT.equals(rootElement))
         {
             iq = new MuteIq();
             String jidStr = parser.getAttributeValue("", MuteIq.JID_ATTR_NAME);

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteVideoIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteVideoIq.java
@@ -35,7 +35,7 @@ public class MuteVideoIq
     /**
      * XML element name of mute packet extension.
      */
-    public static final String ELEMENT_NAME = "mute";
+    public static final String ELEMENT = "mute";
 
     /**
      * Attribute name of "jid".
@@ -67,7 +67,7 @@ public class MuteVideoIq
      */
     public MuteVideoIq()
     {
-        super(ELEMENT_NAME, NAMESPACE);
+        super(ELEMENT, NAMESPACE);
     }
 
     @Override

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteVideoIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/MuteVideoIqProvider.java
@@ -39,7 +39,7 @@ public class MuteVideoIqProvider
     public static void registerMuteVideoIqProvider()
     {
         ProviderManager.addIQProvider(
-            MuteVideoIq.ELEMENT_NAME,
+            MuteVideoIq.ELEMENT,
             MuteVideoIq.NAMESPACE,
             new MuteVideoIqProvider());
     }
@@ -63,7 +63,7 @@ public class MuteVideoIqProvider
 
         MuteVideoIq iq;
 
-        if (MuteVideoIq.ELEMENT_NAME.equals(rootElement))
+        if (MuteVideoIq.ELEMENT.equals(rootElement))
         {
             iq = new MuteVideoIq();
             String jidStr = parser.getAttributeValue("", MuteVideoIq.JID_ATTR_NAME);

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/Nick.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/Nick.java
@@ -18,6 +18,8 @@ package org.jitsi.xmpp.extensions.jitsimeet;
 import org.jitsi.xmpp.extensions.*;
 import org.jivesoftware.smack.provider.*;
 
+import javax.xml.namespace.*;
+
 import static org.jivesoftware.smackx.nick.packet.Nick.*;
 
 /**
@@ -31,6 +33,11 @@ public class Nick
      * The display name.
      */
     private String name = null;
+
+    /**
+     * The qualified name of the element.
+     */
+    private static final QName QNAME = org.jivesoftware.smackx.nick.packet.Nick.QNAME;
 
     /**
      * Constructs Nick extension using original namespace and element name.

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/RegionPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/RegionPacketExtension.java
@@ -28,7 +28,7 @@ public class RegionPacketExtension
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "region";
+    public static final String ELEMENT = "region";
 
     /**
      * XML namespace of this packet extension.
@@ -40,7 +40,7 @@ public class RegionPacketExtension
      */
     public RegionPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ReservationErrorPacketExt.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ReservationErrorPacketExt.java
@@ -33,7 +33,7 @@ public class ReservationErrorPacketExt
     /**
      * XML element name of this packets extension.
      */
-    public static final String ELEMENT_NAME = "reservation-error";
+    public static final String ELEMENT = "reservation-error";
 
     /**
      * The name of XML attribute that holds error code returned by
@@ -46,7 +46,7 @@ public class ReservationErrorPacketExt
      */
     public ReservationErrorPacketExt()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**
@@ -54,7 +54,7 @@ public class ReservationErrorPacketExt
      */
     public ReservationErrorPacketExt(int code)
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
         setErrorCode(code);
     }
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/SSRCInfoPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/SSRCInfoPacketExtension.java
@@ -43,7 +43,7 @@ public class SSRCInfoPacketExtension
     /**
      * XML element name of this packets extension.
      */
-    public static final String ELEMENT_NAME = "ssrc-info";
+    public static final String ELEMENT = "ssrc-info";
 
     /**
      * Attribute stores owner JID of parent {@link SourcePacketExtension}.
@@ -73,7 +73,7 @@ public class SSRCInfoPacketExtension
      */
     public SSRCInfoPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/SessionInvalidPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/SessionInvalidPacketExtension.java
@@ -35,13 +35,13 @@ public class SessionInvalidPacketExtension
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "session-invalid";
+    public static final String ELEMENT = "session-invalid";
 
     /**
      * Creates new instance of <tt>SessionInvalidPacketExtension</tt>
      */
     public SessionInvalidPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/StartMutedPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/StartMutedPacketExtension.java
@@ -33,7 +33,7 @@ public class StartMutedPacketExtension
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "startmuted";
+    public static final String ELEMENT = "startmuted";
 
     /**
      * Attribute name for audio muted.
@@ -50,7 +50,7 @@ public class StartMutedPacketExtension
      */
     public StartMutedPacketExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/StartMutedProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/StartMutedProvider.java
@@ -36,7 +36,7 @@ public class StartMutedProvider
     public static void registerStartMutedProvider()
     {
         ProviderManager.addExtensionProvider(
-            StartMutedPacketExtension.ELEMENT_NAME,
+            StartMutedPacketExtension.ELEMENT,
             StartMutedPacketExtension.NAMESPACE,
             new StartMutedProvider());
     }
@@ -58,7 +58,7 @@ public class StartMutedProvider
             case START_ELEMENT:
             {
                 elementName = parser.getName();
-                if (StartMutedPacketExtension.ELEMENT_NAME.equals(
+                if (StartMutedPacketExtension.ELEMENT.equals(
                     elementName))
                 {
                     boolean audioMute = Boolean.parseBoolean(
@@ -77,7 +77,7 @@ public class StartMutedProvider
             case END_ELEMENT:
             {
                 elementName = parser.getName();
-                if (StartMutedPacketExtension.ELEMENT_NAME.equals(
+                if (StartMutedPacketExtension.ELEMENT.equals(
                     elementName))
                 {
                     done = true;

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/StatsId.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/StatsId.java
@@ -34,7 +34,7 @@ public class StatsId
 {
     public static final String NAMESPACE = "jabber:client";
 
-    public static final String ELEMENT_NAME = "stats-id";
+    public static final String ELEMENT = "stats-id";
 
     private String statsId = null;
 
@@ -71,7 +71,7 @@ public class StatsId
      */
     public String getElementName()
     {
-        return ELEMENT_NAME;
+        return ELEMENT;
     }
 
     /**
@@ -90,7 +90,7 @@ public class StatsId
     public String toXML(XmlEnvironment enclosingNamespace)
     {
         return new XmlStringBuilder()
-            .element(ELEMENT_NAME, getStatsId())
+            .element(ELEMENT, getStatsId())
             .toString();
     }
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/TranscriptionLanguageExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/TranscriptionLanguageExtension.java
@@ -41,7 +41,7 @@ public class TranscriptionLanguageExtension
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME
+    public static final String ELEMENT
         = "jitsi_participant_transcription_language";
 
     /**
@@ -49,7 +49,7 @@ public class TranscriptionLanguageExtension
      */
     public TranscriptionLanguageExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/TranscriptionRequestExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/TranscriptionRequestExtension.java
@@ -33,7 +33,7 @@ public class TranscriptionRequestExtension
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME
+    public static final String ELEMENT
             = "jitsi_participant_requestingTranscription";
 
     /**
@@ -41,6 +41,6 @@ public class TranscriptionRequestExtension
      */
     public TranscriptionRequestExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/TranscriptionStatusExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/TranscriptionStatusExtension.java
@@ -31,7 +31,7 @@ public class TranscriptionStatusExtension
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "transcription-status";
+    public static final String ELEMENT = "transcription-status";
 
     /**
      * The namespace of this packet extension.
@@ -48,7 +48,7 @@ public class TranscriptionStatusExtension
      */
     public TranscriptionStatusExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/TranslationLanguageExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/TranslationLanguageExtension.java
@@ -41,14 +41,14 @@ public class TranslationLanguageExtension
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "jitsi_participant_translation_language";
+    public static final String ELEMENT = "jitsi_participant_translation_language";
 
     /**
      * Creates a {@link TranslationLanguageExtension} instance.
      */
     public TranslationLanguageExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/UserInfoPacketExt.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/UserInfoPacketExt.java
@@ -30,7 +30,7 @@ public class UserInfoPacketExt
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "userinfo";
+    public static final String ELEMENT = "userinfo";
 
     /**
      * Name space of start muted packet extension.
@@ -49,7 +49,7 @@ public class UserInfoPacketExt
      */
     public UserInfoPacketExt()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/VideoMutedExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/VideoMutedExtension.java
@@ -34,14 +34,14 @@ public class VideoMutedExtension
     /**
      * XML element name of this packet extension.
      */
-    public static final String ELEMENT_NAME = "videomuted";
+    public static final String ELEMENT = "videomuted";
 
     /**
      * Creates new instance of <tt>VideoMutedExtension</tt>.
      */
     public VideoMutedExtension()
     {
-        super(NAMESPACE, ELEMENT_NAME);
+        super(NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/rayo/EndExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/rayo/EndExtension.java
@@ -19,6 +19,8 @@ import org.jitsi.xmpp.extensions.*;
 import org.jivesoftware.smack.packet.*;
 import org.jxmpp.jid.Jid;
 
+import javax.xml.namespace.*;
+
 /**
  * 'End' Rayo packet extension used to notify the client about call ended event.
  *
@@ -30,8 +32,13 @@ public class EndExtension
     /**
      * XML element name of this extension.
      */
-    public static final String ELEMENT_NAME = "end";
+    public static final String ELEMENT = "end";
 
+    /**
+     * Qualified name of element.
+     */
+    public static final QName QNAME = new QName(RayoIqProvider.NAMESPACE, ELEMENT);
+    
     /**
      * End reason.
      */
@@ -42,7 +49,7 @@ public class EndExtension
      */
     protected EndExtension()
     {
-        super(RayoIqProvider.NAMESPACE, ELEMENT_NAME);
+        super(RayoIqProvider.NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/rayo/HeaderExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/rayo/HeaderExtension.java
@@ -17,6 +17,8 @@ package org.jitsi.xmpp.extensions.rayo;
 
 import org.jitsi.xmpp.extensions.*;
 
+import javax.xml.namespace.*;
+
 /**
  * Header packet extension optionally included in {@link RayoIqProvider.RayoIq}.
  * Holds 'name' and 'value' attributes.
@@ -29,7 +31,12 @@ public class HeaderExtension
     /**
      * XML element name.
      */
-    public static final String ELEMENT_NAME = "header";
+    public static final String ELEMENT = "header";
+
+    /**
+     * Qualified name of element.
+     */
+    public static final QName QNAME = new QName(RayoIqProvider.NAMESPACE, ELEMENT);
 
     /**
      * The name of 'name' attribute.
@@ -46,7 +53,7 @@ public class HeaderExtension
      */
     public HeaderExtension()
     {
-        super(RayoIqProvider.NAMESPACE, ELEMENT_NAME);
+        super(RayoIqProvider.NAMESPACE, ELEMENT);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/rayo/RayoIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/rayo/RayoIqProvider.java
@@ -48,31 +48,31 @@ public class RayoIqProvider
     {
         // <dial>
         ProviderManager.addIQProvider(
-            DialIq.ELEMENT_NAME,
+            DialIq.ELEMENT,
             NAMESPACE,
             this);
 
         // <ref>
         ProviderManager.addIQProvider(
-            RefIq.ELEMENT_NAME,
+            RefIq.ELEMENT,
             NAMESPACE,
             this);
 
         // <hangup>
         ProviderManager.addIQProvider(
-            HangUp.ELEMENT_NAME,
+            HangUp.ELEMENT,
             NAMESPACE,
             this);
 
         // <end> presence extension
         ProviderManager.addExtensionProvider(
-            EndExtension.ELEMENT_NAME,
+            EndExtension.ELEMENT,
             NAMESPACE,
             new DefaultPacketExtensionProvider<>(EndExtension.class));
 
         // <header> extension
         ProviderManager.addExtensionProvider(
-            HeaderExtension.ELEMENT_NAME,
+            HeaderExtension.ELEMENT,
             NAMESPACE,
             new DefaultPacketExtensionProvider<>(HeaderExtension.class));
     }
@@ -99,7 +99,7 @@ public class RayoIqProvider
         RefIq ref;
         //End end = null;
 
-        if (DialIq.ELEMENT_NAME.equals(rootElement))
+        if (DialIq.ELEMENT.equals(rootElement))
         {
             iq = dial = new DialIq();
             String src = parser.getAttributeValue("", DialIq.SRC_ATTR_NAME);
@@ -112,7 +112,7 @@ public class RayoIqProvider
             dial.setSource(src);
             dial.setDestination(dst);
         }
-        else if (RefIq.ELEMENT_NAME.equals(rootElement))
+        else if (RefIq.ELEMENT.equals(rootElement))
         {
             iq = ref = new RefIq();
             String uri = parser.getAttributeValue("", RefIq.URI_ATTR_NAME);
@@ -122,11 +122,11 @@ public class RayoIqProvider
 
             ref.setUri(uri);
         }
-        else if (HangUp.ELEMENT_NAME.equals(rootElement))
+        else if (HangUp.ELEMENT.equals(rootElement))
         {
             iq = new HangUp();
         }
-        /*else if (End.ELEMENT_NAME.equals(rootElement))
+        /*else if (End.ELEMENT.equals(rootElement))
         {
             iq = end = new End();
         }*/
@@ -151,7 +151,7 @@ public class RayoIqProvider
                     {
                         done = true;
                     }
-                    else if (HeaderExtension.ELEMENT_NAME.equals(
+                    else if (HeaderExtension.ELEMENT.equals(
                         name))
                     {
                         if (header != null)
@@ -177,7 +177,7 @@ public class RayoIqProvider
                 {
                     String name = parser.getName();
 
-                    if (HeaderExtension.ELEMENT_NAME.equals(name))
+                    if (HeaderExtension.ELEMENT.equals(name))
                     {
                         header = new HeaderExtension();
 
@@ -311,7 +311,7 @@ public class RayoIqProvider
         /**
          * The name of XML element for this IQ.
          */
-        public static final String ELEMENT_NAME = "dial";
+        public static final String ELEMENT = "dial";
 
         /**
          * The name of source URI/address attribute. Referred as "source" to
@@ -340,7 +340,7 @@ public class RayoIqProvider
          */
         public DialIq()
         {
-            super(DialIq.ELEMENT_NAME);
+            super(DialIq.ELEMENT);
         }
 
         /**
@@ -436,7 +436,7 @@ public class RayoIqProvider
         /**
          * XML element name of <tt>RefIq</tt>.
          */
-        public static final String ELEMENT_NAME = "ref";
+        public static final String ELEMENT = "ref";
 
         /**
          * Name of the URI attribute that stores call resource reference.
@@ -453,7 +453,7 @@ public class RayoIqProvider
          */
         protected RefIq()
         {
-            super(RefIq.ELEMENT_NAME);
+            super(RefIq.ELEMENT);
         }
 
         /**
@@ -537,14 +537,14 @@ public class RayoIqProvider
         /**
          * The name of 'hangup' element.
          */
-        public static final String ELEMENT_NAME = "hangup";
+        public static final String ELEMENT = "hangup";
 
         /**
          * Creates new instance of <tt>HangUp</tt> IQ.
          */
         protected HangUp()
         {
-            super(ELEMENT_NAME);
+            super(ELEMENT);
         }
 
         /**

--- a/src/main/java/org/jitsi/xmpp/extensions/thumbnail/Thumbnail.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/thumbnail/Thumbnail.java
@@ -32,7 +32,7 @@ public class Thumbnail
     /**
      * The name of the XML element used for transport of thumbnail parameters.
      */
-    public static final String ELEMENT_NAME = "thumbnail";
+    public static final String ELEMENT = "thumbnail";
 
     /**
      * The names XMPP space that the thumbnail elements belong to.
@@ -129,7 +129,7 @@ public class Thumbnail
         StringBuffer buf = new StringBuffer();
 
         // open element
-        buf.append("<").append(ELEMENT_NAME).
+        buf.append("<").append(ELEMENT).
             append(" xmlns=\"").append(NAMESPACE).append("\"");
 
         // adding thumbnail parameters

--- a/src/main/java/org/jitsi/xmpp/extensions/vcardavatar/VCardTempXUpdatePresenceExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/vcardavatar/VCardTempXUpdatePresenceExtension.java
@@ -34,7 +34,7 @@ public class VCardTempXUpdatePresenceExtension
     /**
      * This presence extension element name.
      */
-    public static final String ELEMENT_NAME =  "x";
+    public static final String ELEMENT =  "x";
 
     /**
      * This presence extension namespace.
@@ -156,7 +156,7 @@ public class VCardTempXUpdatePresenceExtension
     @Override
     public String getElementName()
     {
-        return ELEMENT_NAME;
+        return ELEMENT;
     }
 
     /**

--- a/src/test/java/org/jitsi/xmpp/extensions/ExtensionElementQNameDeclaredTest.java
+++ b/src/test/java/org/jitsi/xmpp/extensions/ExtensionElementQNameDeclaredTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 8x8 Inc
+ * Copyright 2021 Florian Schmaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.xmpp.extensions;
+
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.jivesoftware.smack.packet.*;
+import org.jivesoftware.smack.util.XmppElementUtil;
+
+import org.junit.*;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verify that all jitsi XMPP extensions have QNAME (or ELEMENT and NAMESPACE) members,
+ * as is now required by Smack for {@link StanzaView#getExtension(Class)} to work.
+ */
+public class ExtensionElementQNameDeclaredTest
+{
+    @Test
+    public void qnameOrElementNamespaceDeclaredTest()
+    {
+        String[] jitsiXmppExtensionsPackages = new String[] {
+            "org.jitsi.xmpp.extensions",
+        };
+        Reflections reflections = new Reflections(jitsiXmppExtensionsPackages, new SubTypesScanner());
+        Set<Class<? extends ExtensionElement>> extensionElementClasses = reflections.getSubTypesOf(
+            ExtensionElement.class);
+
+        Map<Class<? extends ExtensionElement>, IllegalArgumentException> exceptions = new HashMap<>();
+        for (Class<? extends ExtensionElement> extensionElementClass : extensionElementClasses) {
+            if (Modifier.isAbstract(extensionElementClass.getModifiers())) {
+                continue;
+            }
+
+            try {
+                XmppElementUtil.getQNameFor(extensionElementClass);
+            } catch (IllegalArgumentException e) {
+                exceptions.put(extensionElementClass, e);
+            }
+        }
+
+        Set<Class<? extends ExtensionElement>> failedClasses = exceptions.keySet();
+
+        /* TODO - not all classes are converted.  (This may depend on a newer version of Smack for some.) */
+        /* assertTrue("The following " + failedClasses.size()
+            + " classes are missing QNAME declaration: " + failedClasses, failedClasses.isEmpty()); */
+    }
+}
+

--- a/src/test/java/org/jitsi/xmpp/extensions/colibri/ColibriIQProviderTest.java
+++ b/src/test/java/org/jitsi/xmpp/extensions/colibri/ColibriIQProviderTest.java
@@ -131,7 +131,7 @@ public class ColibriIQProviderTest extends TestCase
         eventType = xmlPullParser.next();
         name = xmlPullParser.getName();
         assertEquals(XmlPullParser.Event.START_ELEMENT, eventType);
-        assertEquals(ColibriConferenceIQ.ELEMENT_NAME, name);
+        assertEquals(ColibriConferenceIQ.ELEMENT, name);
 
         IQ result = colibriIQProvider.parse(xmlPullParser);
         List<SourcePacketExtension> sources =


### PR DESCRIPTION
Needed for them to be retrievable with StanzaView#getExtension(Class) in Smack 4.3.3.