### PR TITLE
fix: make sctp streams attribute optional at parsing.

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/SctpMapExtensionProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/SctpMapExtensionProvider.java
@@ -49,8 +49,11 @@ public class SctpMapExtensionProvider
                 SctpMapExtension.PORT_ATTR_NAME)));
             result.setProtocol(parser.getAttributeValue(null,
                 SctpMapExtension.PROTOCOL_ATTR_NAME));
-            result.setStreams(Integer.parseInt(parser.getAttributeValue(null,
-                SctpMapExtension.STREAMS_ATTR_NAME)));
+            String stream_attr = parser.getAttributeValue(null, SctpMapExtension.STREAMS_ATTR_NAME);
+            if (!stream_attr.isEmpty())
+            {
+                result.setStreams(Integer.parseInt(stream_attr));
+            }
         }
 
         return result;

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/SctpMapExtensionProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/SctpMapExtensionProvider.java
@@ -50,7 +50,7 @@ public class SctpMapExtensionProvider
             result.setProtocol(parser.getAttributeValue(null,
                 SctpMapExtension.PROTOCOL_ATTR_NAME));
             String stream_attr = parser.getAttributeValue(null, SctpMapExtension.STREAMS_ATTR_NAME);
-            if (!stream_attr.isEmpty())
+            if ((stream_attr != null) && (!stream_attr.isEmpty()))
             {
                 result.setStreams(Integer.parseInt(stream_attr));
             }


### PR DESCRIPTION
The client side treats the stream argument from the old SDP syntax as optional, and the RFC syntax for data channels doesn't even have streams at all any more. Making this optional at parsing will allow us to eventually drop the streams argument all together eventually.