### PR TITLE
Add cryptex attribute to fingerprint packet extension.

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONSerializer.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONSerializer.java
@@ -653,6 +653,13 @@ public final class JSONSerializer
             serializeAbstractPacketExtensionAttributes(
                     fingerprint,
                     fingerprintJSONObject);
+            Object cryptex = fingerprintJSONObject.get(DtlsFingerprintPacketExtension.CRYPTEX_ATTR_NAME);
+            if (cryptex instanceof String)
+            {
+                /* Represent cryptex as a boolean. */
+                fingerprintJSONObject.put(DtlsFingerprintPacketExtension.CRYPTEX_ATTR_NAME,
+                    Boolean.parseBoolean((String)cryptex));
+            }
         }
         return fingerprintJSONObject;
     }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/DtlsFingerprintPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/DtlsFingerprintPacketExtension.java
@@ -69,6 +69,12 @@ public class DtlsFingerprintPacketExtension
      */
     private static final String SETUP_ATTR_NAME = "setup";
 
+    /**
+     * The XML name of the <tt>fingerprint</tt> element's attribute which
+     * signals whether it supports the cryptex extension.  Note: This is non-standard.
+     */
+    public static final String CRYPTEX_ATTR_NAME = "cryptex";
+
     /** Initializes a new <tt>DtlsFingerprintPacketExtension</tt> instance. */
     public DtlsFingerprintPacketExtension()
     {
@@ -118,6 +124,17 @@ public class DtlsFingerprintPacketExtension
     }
 
     /**
+     * Returns value of 'cryptex' attribute.  See {@link #CRYPTEX_ATTR_NAME} for more
+     * info.
+     */
+    public boolean getCryptex()
+    {
+        String attr = getAttributeAsString(CRYPTEX_ATTR_NAME);
+
+        return (attr == null) ? false : Boolean.parseBoolean(attr);
+    }
+
+    /**
      * Sets the fingerprint to be carried/represented by this instance.
      *
      * @param fingerprint the fingerprint to be carried/represented by this
@@ -156,5 +173,14 @@ public class DtlsFingerprintPacketExtension
     public void setSetup(String setup)
     {
         setAttribute(SETUP_ATTR_NAME, setup);
+    }
+
+    /**
+     * Sets new value for 'cryptex' attribute.
+     * @param cryptex see {@link #CRYPTEX_ATTR_NAME} for details.
+     */
+    public void setCryptex(Boolean cryptex)
+    {
+        setAttribute(CRYPTEX_ATTR_NAME, cryptex);
     }
 }

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializerTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializerTest.kt
@@ -285,7 +285,7 @@ private val expectedMappings = listOf(
     <endpoint xmlns="jitsi:colibri2" id="79f0273e">
       <transport>
         <transport xmlns="urn:xmpp:jingle:transports:ice-udp:1" pwd="1a5ejbent91k6io6a3fauikg22" ufrag="2ivqh1fvtf0l3h">
-          <fingerprint xmlns="urn:xmpp:jingle:apps:dtls:0" setup="actpass" hash="sha-256">2E:CC:85:71:32:5B:B5:60:64:C8:F6:7B:6D:45:D4:34:2B:51:A0:06:B5:EA:2F:84:BC:7B:64:1F:A3:0A:69:23</fingerprint>
+          <fingerprint xmlns="urn:xmpp:jingle:apps:dtls:0" setup="actpass" hash="sha-256" cryptex="true">2E:CC:85:71:32:5B:B5:60:64:C8:F6:7B:6D:45:D4:34:2B:51:A0:06:B5:EA:2F:84:BC:7B:64:1F:A3:0A:69:23</fingerprint>
           <web-socket xmlns="http://jitsi.org/protocol/colibri" url="wss://beta-us-ashburn-1-global-2808-jvb-83-102-26.jitsi.net:443/colibri-ws/default-id/3d937bbdf97a23e0/79f0273e?pwd=1a5ejbent91k6io6a3fauikg22"/>
           <rtcp-mux/>
           <candidate component="1" foundation="2" generation="0" id="653aa1ba295b62480ffffffffdc52c0d9" network="0" priority="1694498815" protocol="udp" type="srflx" ip="129.80.210.199" port="10000" rel-addr="0.0.0.0" rel-port="9"/>
@@ -342,7 +342,8 @@ private val expectedMappings = listOf(
             {
               "fingerprint": "2E:CC:85:71:32:5B:B5:60:64:C8:F6:7B:6D:45:D4:34:2B:51:A0:06:B5:EA:2F:84:BC:7B:64:1F:A3:0A:69:23",
               "setup": "actpass",
-              "hash": "sha-256"
+              "hash": "sha-256",
+              "cryptex": true
             }
           ]
         }


### PR DESCRIPTION
Supports draft-ietf-avtcore-cryptex.  Part of a package with https://github.com/jitsi/jitsi-srtp/pull/29, https://github.com/jitsi/lib-jitsi-meet/pull/2150, and https://github.com/jitsi/jitsi-videobridge/pull/1969.