### PR TITLE
ref(colibri2 session participant re-invite): new error reason for unknown endpoint

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/colibri2/Colibri2Error.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri2/Colibri2Error.java
@@ -96,6 +96,7 @@ public class Colibri2Error
         CONFERENCE_NOT_FOUND,
         CONFERENCE_ALREADY_EXISTS,
         GRACEFUL_SHUTDOWN,
+        UNKNOWN_ENDPOINT,
         UNSPECIFIED;
 
         @NotNull


### PR DESCRIPTION
Added Additional UNKNOWN_ENDPOINT Colibri2Error reason to recognise situation when participant should be re-invited in situation when jicofo sends e.g. participant update and its endpoint was expired on jvb. Upon this error jicofo should re-invite participant and not invalidate the whole bridge.
Added this change as part of https://github.com/jitsi/jicofo/issues/1047