### PR TITLE
Don't call toString() in AbstractPacketExtension.toXML()'s return.

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/AbstractPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/AbstractPacketExtension.java
@@ -153,7 +153,7 @@ public abstract class AbstractPacketExtension
      *
      * @return an XML representation of this extension.
      */
-    public String toXML(XmlEnvironment enclosingNamespace)
+    public CharSequence toXML(XmlEnvironment enclosingNamespace)
     {
         XmlStringBuilder xml = new XmlStringBuilder(this, enclosingNamespace);
 
@@ -207,7 +207,7 @@ public abstract class AbstractPacketExtension
 
         xml.closeElement(getElementName());
 
-        return xml.toString();
+        return xml;
     }
 
     /**


### PR DESCRIPTION
It only needs to return a CharSequence, which XmlStringBuilder already satisfies. This should eliminate redundant stringification of xml.