### PR TITLE
Recognize jitsi_participant_codecList as an xmpp extension.

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ConferenceProperties.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/ConferenceProperties.java
@@ -74,6 +74,12 @@ public class ConferenceProperties
     public static final String KEY_VISITOR_COUNT = "visitor-count";
 
     /**
+     * The property key used to indicate the set of video codecs supported by all visitors
+     * currently in the conference
+     */
+    public static final String KEY_VISITOR_CODECS = "visitor-codecs";
+
+    /**
      * The property key used to signal support for session restart to the current conference.
      */
     public static final String KEY_SUPPORTS_SESSION_RESTART = "support-terminate-restart";

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/jitsimeet/JitsiParticipantCodecList.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/jitsimeet/JitsiParticipantCodecList.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright @ 2023 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.xmpp.extensions.jitsimeet
+
+import org.jitsi.xmpp.extensions.AbstractPacketExtension
+
+class JitsiParticipantCodecList : AbstractPacketExtension(NAMESPACE, ELEMENT) {
+    var codecs: List<String>
+        get() = text?.lowercase()?.split(',') ?: emptyList()
+        set(value) {
+            text = value.joinToString(separator = ",").lowercase()
+        }
+
+    companion object {
+        const val ELEMENT = "jitsi_participant_codecList"
+        const val NAMESPACE = "jabber:client"
+    }
+}

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/jitsimeet/JitsiParticipantCodecListTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/jitsimeet/JitsiParticipantCodecListTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright @ 2023 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.xmpp.extensions.jitsimeet
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.jitsi.xmpp.extensions.DefaultPacketExtensionProvider
+import org.jivesoftware.smack.provider.ProviderManager
+import org.jivesoftware.smack.util.PacketParserUtils
+
+class JitsiParticipantCodecListTest : ShouldSpec() {
+    private val sampleXml =
+        """
+            <presence xmlns="jabber:client" xml:lang="en" to="focus@auth.example" from="test@conference.example/deadbeef">
+              <jitsi_participant_codecList>vp9,vp8,h264</jitsi_participant_codecList>
+            </presence>
+        """.trimIndent()
+
+    init {
+        context("Getting a codec list set from its text") {
+            val codecList = JitsiParticipantCodecList()
+            codecList.text = "vp9,vp8,h264"
+            should("Parse as the appropriate list of codecs") {
+                codecList.codecs.shouldContainExactly("vp9", "vp8", "h264")
+            }
+        }
+        context("codec values in text") {
+            val codecList = JitsiParticipantCodecList()
+            codecList.text = "VP9,VP8,H264"
+            should("be case-normalized when read") {
+                codecList.codecs.shouldContainExactly("vp9", "vp8", "h264")
+            }
+        }
+        context("Setting a codec list") {
+            val codecList = JitsiParticipantCodecList()
+            codecList.codecs = listOf("vp9", "vp8", "h264")
+            should("Be serialized properly") {
+                codecList.text shouldBe "vp9,vp8,h264"
+            }
+        }
+        context("Codec values as set") {
+            val codecList = JitsiParticipantCodecList()
+            codecList.codecs = listOf("VP9", "VP8", "H264")
+            should("be case-normalized when serialized") {
+                codecList.text shouldBe "vp9,vp8,h264"
+            }
+        }
+        context("Parsing a Presence stanza containing a codec list") {
+            ProviderManager.addExtensionProvider(
+                JitsiParticipantCodecList.ELEMENT,
+                JitsiParticipantCodecList.NAMESPACE,
+                DefaultPacketExtensionProvider(JitsiParticipantCodecList::class.java)
+            )
+
+            val parser = PacketParserUtils.getParserFor(sampleXml)
+            val presence = PacketParserUtils.parsePresence(parser)
+            val codecList = presence.getExtension(JitsiParticipantCodecList::class.java)
+            should("Parse properly") {
+                codecList shouldNotBe null
+                codecList.codecs.shouldContainExactly("vp9", "vp8", "h264")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add VISITOR_CODECS to ConferenceProperties.