### PR TITLE
Fix cloning DtlsFingerprintPacketExtension

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/DtlsFingerprintPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/DtlsFingerprintPacketExtension.java
@@ -183,4 +183,16 @@ public class DtlsFingerprintPacketExtension
     {
         setAttribute(CRYPTEX_ATTR_NAME, cryptex);
     }
+
+    public DtlsFingerprintPacketExtension copy()
+    {
+        DtlsFingerprintPacketExtension copy = new DtlsFingerprintPacketExtension();
+        copy.setFingerprint(getFingerprint());
+        copy.setHash(getHash());
+        copy.setRequired(getRequired());
+        copy.setSetup(getSetup());
+        copy.setCryptex(getCryptex());
+
+        return copy;
+    }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/IceUdpTransportPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/IceUdpTransportPacketExtension.java
@@ -324,16 +324,7 @@ public class IceUdpTransportPacketExtension
                 : src.getChildExtensionsOfType(
                 DtlsFingerprintPacketExtension.class))
             {
-                DtlsFingerprintPacketExtension copy
-                    = new DtlsFingerprintPacketExtension();
-
-                copy.setFingerprint(dtlsFingerprint.getFingerprint());
-                copy.setHash(dtlsFingerprint.getHash());
-                copy.setRequired(dtlsFingerprint.getRequired());
-                copy.setSetup(dtlsFingerprint.getSetup());
-                copy.setCryptex(dtlsFingerprint.getCryptex());
-
-                dst.addChildExtension(copy);
+                dst.addChildExtension(dtlsFingerprint.copy());
             }
         }
         return dst;

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/IceUdpTransportPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/IceUdpTransportPacketExtension.java
@@ -331,6 +331,7 @@ public class IceUdpTransportPacketExtension
                 copy.setHash(dtlsFingerprint.getHash());
                 copy.setRequired(dtlsFingerprint.getRequired());
                 copy.setSetup(dtlsFingerprint.getSetup());
+                copy.setCryptex(dtlsFingerprint.getCryptex());
 
                 dst.addChildExtension(copy);
             }


### PR DESCRIPTION
- **fix: Also copy the cryptex flag when cloning DtlsFingerprintPacketExtension.**
- **ref: Move clone function to DtlsFingerprintPacketExtension.**
