### PR TITLE
Add rtcstats_enabled field to JibriIq

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIq.java
@@ -111,6 +111,11 @@ public class JibriIq
     static final String APP_DATA_ATTR_NAME = "app_data";
 
     /**
+     * The name of the XML attribute which stores whether rtcstats is enabled.
+     */
+    static final String RTCSTATS_ENABLED_ATTR_NAME = "rtcstats_enabled";
+
+    /**
      * The name of XML attribute which stores the recording mode which can be
      * either 'stream' or 'file'. If the attribute is not present, but
      * {@link #STREAM_ID_ATTR_NAME} is, then it defaults to 'stream'. But if
@@ -202,6 +207,11 @@ public class JibriIq
      * The name of the conference room to be recorded.
      */
     private EntityBareJid room = null;
+
+    /**
+     * Whether rtcstats is enabled for this conference. Null means not specified.
+     */
+    private Boolean rtcStatsEnabled = null;
 
     public JibriIq()
     {
@@ -343,6 +353,16 @@ public class JibriIq
         this.room = room;
     }
 
+    public Boolean getRtcStatsEnabled()
+    {
+        return rtcStatsEnabled;
+    }
+
+    public void setRtcStatsEnabled(Boolean rtcStatsEnabled)
+    {
+        this.rtcStatsEnabled = rtcStatsEnabled;
+    }
+
     /**
      * Whether or not this IQ represents a failure from Jibri
      * @return true if it represents failure, false otherwise
@@ -385,6 +405,10 @@ public class JibriIq
             xml.attribute(SHOULD_RETRY_ATTR_NAME, shouldRetry);
         }
         xml.optAttribute(APP_DATA_ATTR_NAME, appData);
+        if (rtcStatsEnabled != null)
+        {
+            xml.attribute(RTCSTATS_ENABLED_ATTR_NAME, rtcStatsEnabled);
+        }
 
         xml.setEmptyElement();
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
@@ -121,6 +121,13 @@ public class JibriIqProvider
                 = parser.getAttributeValue("", JibriIq.SIP_ADDRESS_ATTR_NAME);
             if (StringUtils.isNotEmpty(sipAddress))
                 iq.setSipAddress(sipAddress);
+
+            String rtcStatsEnabledStr
+                = parser.getAttributeValue("", JibriIq.RTCSTATS_ENABLED_ATTR_NAME);
+            if (StringUtils.isNotEmpty(rtcStatsEnabledStr))
+            {
+                iq.setRtcStatsEnabled(Boolean.valueOf(rtcStatsEnabledStr));
+            }
         }
         else
         {

--- a/src/test/java/org/jitsi/xmpp/extensions/jibri/JibriIqProviderTest.java
+++ b/src/test/java/org/jitsi/xmpp/extensions/jibri/JibriIqProviderTest.java
@@ -18,6 +18,7 @@ package org.jitsi.xmpp.extensions.jibri;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.jitsi.xmpp.extensions.*;
+import org.jivesoftware.smack.packet.*;
 import org.junit.jupiter.api.*;
 
 /**
@@ -54,5 +55,56 @@ public class JibriIqProviderTest
         assertTrue(jibriIq.getSessionId().equalsIgnoreCase("abcd"));
 
         assertNull(jibriIq.getError());
+    }
+
+    @Test
+    public void testParseRtcStatsEnabled()
+        throws Exception
+    {
+        JibriIqProvider provider = new JibriIqProvider();
+
+        String iqWithTrue =
+            "<iq to='t' from='f' type='set'>" +
+                "<jibri xmlns='http://jitsi.org/protocol/jibri'" +
+                "   action='start' rtcstats_enabled='true'" +
+                "/>" +
+                "</iq>";
+        JibriIq iqTrue = IQUtils.parse(iqWithTrue, provider);
+        assertEquals(Boolean.TRUE, iqTrue.getRtcStatsEnabled());
+
+        String iqWithFalse =
+            "<iq to='t' from='f' type='set'>" +
+                "<jibri xmlns='http://jitsi.org/protocol/jibri'" +
+                "   action='start' rtcstats_enabled='false'" +
+                "/>" +
+                "</iq>";
+        JibriIq iqFalse = IQUtils.parse(iqWithFalse, provider);
+        assertEquals(Boolean.FALSE, iqFalse.getRtcStatsEnabled());
+
+        String iqWithoutFlag =
+            "<iq to='t' from='f' type='set'>" +
+                "<jibri xmlns='http://jitsi.org/protocol/jibri'" +
+                "   action='start'" +
+                "/>" +
+                "</iq>";
+        JibriIq iqAbsent = IQUtils.parse(iqWithoutFlag, provider);
+        assertNull(iqAbsent.getRtcStatsEnabled());
+    }
+
+    @Test
+    public void testSerializeRtcStatsEnabled()
+    {
+        JibriIq iq = new JibriIq();
+        iq.setType(IQ.Type.set);
+        iq.setAction(JibriIq.Action.START);
+
+        iq.setRtcStatsEnabled(true);
+        assertTrue(iq.toXML().toString().contains("rtcstats_enabled='true'"));
+
+        iq.setRtcStatsEnabled(false);
+        assertTrue(iq.toXML().toString().contains("rtcstats_enabled='false'"));
+
+        iq.setRtcStatsEnabled(null);
+        assertFalse(iq.toXML().toString().contains("rtcstats_enabled"));
     }
 }


### PR DESCRIPTION
Add `rtcstats_enabled` XML attribute to `JibriIq` so jicofo can forward the conference-level rtcstats flag to Jibri.

- New `rtcstats_enabled` attribute (optional boolean, omitted when null)
- Serialization and parsing support in `JibriIq`/`JibriIqProvider`
- Tests for both parse and serialize paths