### PR TITLE
Replace json-simple with Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.jitsi</groupId>
       <artifactId>jitsi-utils</artifactId>
-      <version>1.0-143-g65e2bd7</version>
+      <version>1.0-150-g4ab9a3b</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,16 @@
       <version>1.0-143-g65e2bd7</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.19.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-kotlin</artifactId>
+      <version>2.19.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.12.0</version>

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONDeserializer.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONDeserializer.java
@@ -261,7 +261,8 @@ public final class JSONDeserializer
                 if (typeNode != null && !typeNode.isTextual())
                     throw new IllegalArgumentException("Expected string rtcp-fb type, got: " + typeNode.getNodeType());
                 if (subtypeNode != null && !subtypeNode.isTextual())
-                    throw new IllegalArgumentException("Expected string rtcp-fb subtype, got: " + subtypeNode.getNodeType());
+                    throw new IllegalArgumentException(
+                        "Expected string rtcp-fb subtype, got: " + subtypeNode.getNodeType());
                 String type = typeNode != null ? typeNode.asText() : null;
                 String subtype = subtypeNode != null ? subtypeNode.asText() : null;
                 if (type != null)
@@ -291,9 +292,11 @@ public final class JSONDeserializer
             JsonNode idNode = headerExtension.get(RTPHdrExtPacketExtension.ID_ATTR_NAME);
             JsonNode uriNode = headerExtension.get(RTPHdrExtPacketExtension.URI_ATTR_NAME);
             if (idNode != null && !idNode.isNumber())
-                throw new IllegalArgumentException("Expected numeric header extension id, got: " + idNode.getNodeType());
+                throw new IllegalArgumentException(
+                    "Expected numeric header extension id, got: " + idNode.getNodeType());
             if (uriNode != null && !uriNode.isTextual())
-                throw new IllegalArgumentException("Expected string header extension uri, got: " + uriNode.getNodeType());
+                throw new IllegalArgumentException(
+                    "Expected string header extension uri, got: " + uriNode.getNodeType());
             Long id = idNode != null ? idNode.asLong() : null;
             String uriString = uriNode != null ? uriNode.asText() : null;
             URI uri;
@@ -356,7 +359,8 @@ public final class JSONDeserializer
             if (parameters != null && !parameters.isNull())
             {
                 if (!(parameters instanceof ObjectNode))
-                    throw new IllegalArgumentException("Expected object for parameters, got: " + parameters.getNodeType());
+                    throw new IllegalArgumentException(
+                        "Expected object for parameters, got: " + parameters.getNodeType());
                 deserializeParameters((ObjectNode) parameters, payloadTypeIQ);
             }
 
@@ -442,7 +446,8 @@ public final class JSONDeserializer
             if (parameters != null && !parameters.isNull())
             {
                 if (!(parameters instanceof ObjectNode))
-                    throw new IllegalArgumentException("Expected object for source parameters, got: " + parameters.getNodeType());
+                    throw new IllegalArgumentException(
+                        "Expected object for source parameters, got: " + parameters.getNodeType());
                 parameters.properties().forEach(e ->
                 {
                     JsonNode paramValueNode = e.getValue();
@@ -502,7 +507,8 @@ public final class JSONDeserializer
                         .get(JSONSerializer.SOURCES);
 
                 if (sourcesObject != null && !sourcesObject.isNull() && !(sourcesObject instanceof ArrayNode))
-                    throw new IllegalArgumentException("Expected array for sources, got: " + sourcesObject.getNodeType());
+                    throw new IllegalArgumentException(
+                        "Expected array for sources, got: " + sourcesObject.getNodeType());
 
                 if (sourcesObject instanceof ArrayNode && ((ArrayNode) sourcesObject).size() != 0)
                 {
@@ -606,27 +612,31 @@ public final class JSONDeserializer
                 if (fingerprints != null && !fingerprints.isNull())
                 {
                     if (!(fingerprints instanceof ArrayNode))
-                        throw new IllegalArgumentException("Expected array for fingerprints, got: " + fingerprints.getNodeType());
+                        throw new IllegalArgumentException(
+                            "Expected array for fingerprints, got: " + fingerprints.getNodeType());
                     deserializeFingerprints((ArrayNode) fingerprints, transportIQ);
                 }
                 // candidateList
                 if (candidateList != null && !candidateList.isNull())
                 {
                     if (!(candidateList instanceof ArrayNode))
-                        throw new IllegalArgumentException("Expected array for candidates, got: " + candidateList.getNodeType());
+                        throw new IllegalArgumentException(
+                            "Expected array for candidates, got: " + candidateList.getNodeType());
                     deserializeCandidates((ArrayNode) candidateList, transportIQ);
                 }
                 if (webSocketList != null && !webSocketList.isNull())
                 {
                     if (!(webSocketList instanceof ArrayNode))
-                        throw new IllegalArgumentException("Expected array for websockets, got: " + webSocketList.getNodeType());
+                        throw new IllegalArgumentException(
+                            "Expected array for websockets, got: " + webSocketList.getNodeType());
                     deserializeWebsockets((ArrayNode) webSocketList, transportIQ);
                 }
                 // remoteCandidate
                 if (remoteCandidate != null && !remoteCandidate.isNull())
                 {
                     if (!(remoteCandidate instanceof ObjectNode))
-                        throw new IllegalArgumentException("Expected object for remoteCandidate, got: " + remoteCandidate.getNodeType());
+                        throw new IllegalArgumentException(
+                            "Expected object for remoteCandidate, got: " + remoteCandidate.getNodeType());
                     deserializeCandidate(
                             (ObjectNode) remoteCandidate,
                             RemoteCandidatePacketExtension.class,

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONDeserializer.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONDeserializer.java
@@ -509,16 +509,16 @@ public final class JSONDeserializer
         return sourceGroupIQ;
     }
 
-    public static long deserializeSSRC(JsonNode o)
+    public static int deserializeSSRC(JsonNode o)
         throws NumberFormatException
     {
-        long i = 0;
+        int i = 0;
 
         if (o != null && !o.isNull())
         {
             if (o.isNumber())
             {
-                i = o.asLong();
+                i = o.asInt();
             }
             else
             {
@@ -530,7 +530,7 @@ public final class JSONDeserializer
                 }
                 else
                 {
-                    i = Long.parseLong(s);
+                    i = (int) Long.parseLong(s);
                 }
             }
         }

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONDeserializer.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONDeserializer.java
@@ -19,10 +19,11 @@ import java.lang.reflect.*;
 import java.net.*;
 import java.util.*;
 
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.node.*;
 import org.jitsi.xmpp.extensions.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
-import org.json.simple.*;
 
 /**
  * Implements (utility) functions to deserialize instances of
@@ -30,53 +31,46 @@ import org.json.simple.*;
  *
  * @author Lyubomir Marinov
  */
-@SuppressWarnings("unchecked")
 public final class JSONDeserializer
 {
     /**
-     * Deserializes the values of a <tt>JSONObject</tt> which are neither
-     * <tt>JSONArray</tt>, nor <tt>JSONObject</tt> into attribute values
+     * Deserializes the values of a <tt>ObjectNode</tt> which are neither
+     * <tt>ArrayNode</tt>, nor <tt>ObjectNode</tt> into attribute values
      * a <tt>AbstractPacketExtension</tt>.
      *
-     * @param jsonObject the <tt>JSONObject</tt> whose values which are neither
-     * <tt>JSONArray</tt>, nor <tt>JSONObject</tt> to deserialize into attribute
+     * @param jsonObject the <tt>ObjectNode</tt> whose values which are neither
+     * <tt>ArrayNode</tt>, nor <tt>ObjectNode</tt> to deserialize into attribute
      * values of <tt>abstractPacketExtension</tt>
      * @param abstractPacketExtension the <tt>AbstractPacketExtension</tt> in
      * the attributes of which the values of <tt>jsonObject</tt> which are
-     * neither <tt>JSONObject</tt>, nor <tt>JSONArray</tt> are to be
+     * neither <tt>ObjectNode</tt>, nor <tt>ArrayNode</tt> are to be
      * deserialized
      */
     public static void deserializeAbstractPacketExtensionAttributes(
-            JSONObject jsonObject,
+            ObjectNode jsonObject,
             AbstractPacketExtension abstractPacketExtension)
     {
-
-        for (Map.Entry<Object, Object> e : (Iterable<Map.Entry<Object,
-            Object>>) jsonObject
-            .entrySet())
+        jsonObject.fields().forEachRemaining(e ->
         {
-            Object key = e.getKey();
+            String name = e.getKey();
+            JsonNode value = e.getValue();
 
-            if (key != null)
+            if (name != null && !(value instanceof ObjectNode) && !(value instanceof ArrayNode))
             {
-                String name = key.toString();
-
-                if (name != null)
-                {
-                    Object value = e.getValue();
-
-                    if (!(value instanceof JSONObject)
-                        && !(value instanceof JSONArray))
-                    {
-                        abstractPacketExtension.setAttribute(name, value);
-                    }
-                }
+                if (value.isTextual())
+                    abstractPacketExtension.setAttribute(name, value.asText());
+                else if (value.isBoolean())
+                    abstractPacketExtension.setAttribute(name, value.asBoolean());
+                else if (value.isNumber())
+                    abstractPacketExtension.setAttribute(name, value.asLong());
+                else
+                    abstractPacketExtension.setAttribute(name, value.asText());
             }
-        }
+        });
     }
 
     public static <T extends CandidatePacketExtension> T deserializeCandidate(
-            JSONObject candidate,
+            ObjectNode candidate,
             Class<T> candidateIQClass,
             IceUdpTransportPacketExtension transportIQ)
     {
@@ -108,15 +102,15 @@ public final class JSONDeserializer
     }
 
     public static void deserializeCandidates(
-            JSONArray candidates,
+            ArrayNode candidates,
             IceUdpTransportPacketExtension transportIQ)
     {
-        if ((candidates != null) && !candidates.isEmpty())
+        if ((candidates != null) && candidates.size() > 0)
         {
-            for (Object candidate : candidates)
+            for (JsonNode candidate : candidates)
             {
                 deserializeCandidate(
-                        (JSONObject) candidate,
+                        (ObjectNode) candidate,
                         IceCandidatePacketExtension.class,
                         transportIQ);
             }
@@ -151,34 +145,31 @@ public final class JSONDeserializer
     }
 
     public static void deserializeWebsockets(
-        JSONArray webSockets,
+        ArrayNode webSockets,
         IceUdpTransportPacketExtension transportIQ)
     {
-        if ((webSockets != null) && !webSockets.isEmpty())
+        if ((webSockets != null) && webSockets.size() > 0)
         {
-            for (Object webSocket : webSockets)
+            for (JsonNode webSocket : webSockets)
             {
                 deserializeWebsocket(
-                    (String)webSocket,
+                    webSocket.isTextual() ? webSocket.asText() : null,
                     transportIQ);
             }
         }
     }
 
-    private static Boolean objectToBoolean(Object o)
+    private static Boolean jsonNodeToBoolean(JsonNode node)
     {
-        if (o instanceof Boolean)
-        {
-            return (Boolean) o;
-        }
-        else
-        {
-            return Boolean.valueOf(o.toString());
-        }
+        if (node == null)
+            return null;
+        if (node.isBoolean())
+            return node.asBoolean();
+        return Boolean.valueOf(node.asText());
     }
 
     public static DtlsFingerprintPacketExtension deserializeFingerprint(
-            JSONObject fingerprint,
+            ObjectNode fingerprint,
             IceUdpTransportPacketExtension transportIQ)
     {
         DtlsFingerprintPacketExtension fingerprintIQ;
@@ -189,14 +180,14 @@ public final class JSONDeserializer
         }
         else
         {
-            Object theFingerprint
+            JsonNode theFingerprint
                 = fingerprint.get(DtlsFingerprintPacketExtension.ELEMENT);
 
             fingerprintIQ = new DtlsFingerprintPacketExtension();
             // fingerprint
             if (theFingerprint != null)
             {
-                fingerprintIQ.setFingerprint(theFingerprint.toString());
+                fingerprintIQ.setFingerprint(theFingerprint.asText());
             }
             // attributes
             deserializeAbstractPacketExtensionAttributes(
@@ -219,63 +210,56 @@ public final class JSONDeserializer
     }
 
     public static void deserializeFingerprints(
-            JSONArray fingerprints,
+            ArrayNode fingerprints,
             IceUdpTransportPacketExtension transportIQ)
     {
-        if ((fingerprints != null) && !fingerprints.isEmpty())
+        if ((fingerprints != null) && fingerprints.size() > 0)
         {
-            for (Object fingerprint : fingerprints)
+            for (JsonNode fingerprint : fingerprints)
             {
-                deserializeFingerprint((JSONObject) fingerprint, transportIQ);
+                deserializeFingerprint((ObjectNode) fingerprint, transportIQ);
             }
         }
     }
 
     public static void deserializeParameters(
-            JSONObject parameters,
+            ObjectNode parameters,
             PayloadTypePacketExtension payloadTypeIQ)
     {
         if (parameters != null)
         {
-
-            for (Map.Entry<Object, Object> e
-                        : (Iterable<Map.Entry<Object, Object>>) parameters
-                                .entrySet())
+            parameters.fields().forEachRemaining(e ->
             {
-                Object name = e.getKey();
-                Object value = e.getValue();
+                String name = e.getKey();
+                JsonNode valueNode = e.getValue();
+                String value = valueNode.isNull() ? null : valueNode.asText();
 
                 /* Some payload formats - notably red - have a parameter without a name, but
                  * JSON doesn't allow null as a key name */
-                if (name instanceof String && name.equals("null"))
-                {
-                    name = null;
-                }
+                String actualName = "null".equals(name) ? null : name;
 
-                if ((name != null) || (value != null))
+                if ((actualName != null) || (value != null))
                 {
                     payloadTypeIQ.addParameter(
-                            new ParameterPacketExtension(
-                                    Objects.toString(name, null),
-                                    Objects.toString(value, null)));
+                            new ParameterPacketExtension(actualName, value));
                 }
-            }
+            });
         }
     }
 
     public static void deserializeRtcpFbs(
-            JSONArray rtcpFbs,
+            ArrayNode rtcpFbs,
             PayloadTypePacketExtension payloadTypeIQ)
     {
         if (rtcpFbs != null)
         {
-            for (Object iter : rtcpFbs)
+            for (JsonNode iter : rtcpFbs)
             {
-                JSONObject rtcpFb = (JSONObject) iter;
-                String type = (String)
-                        rtcpFb.get(RtcpFbPacketExtension.TYPE_ATTR_NAME);
-                String subtype = (String)
-                        rtcpFb.get(RtcpFbPacketExtension.SUBTYPE_ATTR_NAME);
+                ObjectNode rtcpFb = (ObjectNode) iter;
+                JsonNode typeNode = rtcpFb.get(RtcpFbPacketExtension.TYPE_ATTR_NAME);
+                JsonNode subtypeNode = rtcpFb.get(RtcpFbPacketExtension.SUBTYPE_ATTR_NAME);
+                String type = (typeNode != null && typeNode.isTextual()) ? typeNode.asText() : null;
+                String subtype = (subtypeNode != null && subtypeNode.isTextual()) ? subtypeNode.asText() : null;
                 if (type != null)
                 {
                     RtcpFbPacketExtension ext = new RtcpFbPacketExtension();
@@ -291,7 +275,7 @@ public final class JSONDeserializer
     }
 
     public static RTPHdrExtPacketExtension deserializeHeaderExtension(
-            JSONObject headerExtension)
+            ObjectNode headerExtension)
     {
         RTPHdrExtPacketExtension headerExtensionIQ;
         if (headerExtension == null)
@@ -300,18 +284,20 @@ public final class JSONDeserializer
         }
         else
         {
-            Long id = (Long)headerExtension.get(RTPHdrExtPacketExtension.ID_ATTR_NAME);
-            String uriString = (String)headerExtension.get(RTPHdrExtPacketExtension.URI_ATTR_NAME);
+            JsonNode idNode = headerExtension.get(RTPHdrExtPacketExtension.ID_ATTR_NAME);
+            JsonNode uriNode = headerExtension.get(RTPHdrExtPacketExtension.URI_ATTR_NAME);
+            Long id = (idNode != null && idNode.isNumber()) ? idNode.asLong() : null;
+            String uriString = (uriNode != null && uriNode.isTextual()) ? uriNode.asText() : null;
             URI uri;
             try
             {
-                uri = new URI(uriString);
+                uri = uriString != null ? new URI(uriString) : null;
             }
             catch (URISyntaxException e)
             {
                 uri = null;
             }
-            if (uri != null)
+            if (uri != null && id != null)
             {
                 headerExtensionIQ = new RTPHdrExtPacketExtension();
                 headerExtensionIQ.setID(String.valueOf(id));
@@ -326,12 +312,12 @@ public final class JSONDeserializer
     }
 
     public static Collection<RTPHdrExtPacketExtension> deserializeHeaderExtensions(
-        JSONArray headerExtensions)
+        ArrayNode headerExtensions)
     {
         Collection<RTPHdrExtPacketExtension> headerExtensionIQs = new ArrayList<>();
-        for (Object headerExtension : headerExtensions)
+        for (JsonNode headerExtension : headerExtensions)
         {
-            RTPHdrExtPacketExtension headerExtensionIQ = deserializeHeaderExtension((JSONObject) headerExtension);
+            RTPHdrExtPacketExtension headerExtensionIQ = deserializeHeaderExtension((ObjectNode) headerExtension);
             if (headerExtensionIQ != null)
             {
                 headerExtensionIQs.add(headerExtensionIQ);
@@ -341,7 +327,7 @@ public final class JSONDeserializer
     }
 
     public static PayloadTypePacketExtension deserializePayloadType(
-            JSONObject payloadType)
+            ObjectNode payloadType)
     {
         PayloadTypePacketExtension payloadTypeIQ;
 
@@ -351,7 +337,7 @@ public final class JSONDeserializer
         }
         else
         {
-            Object parameters = payloadType.get(JSONSerializer.PARAMETERS);
+            JsonNode parameters = payloadType.get(JSONSerializer.PARAMETERS);
 
             payloadTypeIQ = new PayloadTypePacketExtension();
             // attributes
@@ -359,42 +345,42 @@ public final class JSONDeserializer
                     payloadType,
                     payloadTypeIQ);
             // parameters
-            if (parameters != null)
+            if (parameters instanceof ObjectNode)
             {
-                deserializeParameters((JSONObject) parameters, payloadTypeIQ);
+                deserializeParameters((ObjectNode) parameters, payloadTypeIQ);
             }
 
-            Object rtcpFbs = payloadType.get(JSONSerializer.RTCP_FBS);
+            JsonNode rtcpFbs = payloadType.get(JSONSerializer.RTCP_FBS);
 
-            if (rtcpFbs instanceof JSONArray)
+            if (rtcpFbs instanceof ArrayNode)
             {
-                deserializeRtcpFbs((JSONArray) rtcpFbs, payloadTypeIQ);
+                deserializeRtcpFbs((ArrayNode) rtcpFbs, payloadTypeIQ);
             }
         }
         return payloadTypeIQ;
     }
 
     public static Collection<PayloadTypePacketExtension> deserializePayloadTypes(
-            JSONArray payloadTypes)
+            ArrayNode payloadTypes)
     {
         Collection<PayloadTypePacketExtension> payloadTypeIQs = new ArrayList<>();
-        for (Object payloadType : payloadTypes)
+        for (JsonNode payloadType : payloadTypes)
         {
-            payloadTypeIQs.add(deserializePayloadType((JSONObject) payloadType));
+            payloadTypeIQs.add(deserializePayloadType((ObjectNode) payloadType));
         }
         return payloadTypeIQs;
     }
 
 
-    public static SourcePacketExtension deserializeSource(Object source)
+    public static SourcePacketExtension deserializeSource(JsonNode source)
     {
         SourcePacketExtension sourceIQ;
 
-        if (source == null)
+        if (source == null || source.isNull())
         {
             sourceIQ = null;
         }
-        else if (source instanceof Number || source instanceof String)
+        else if (source.isNumber() || source.isTextual())
         {
             long ssrc;
             try
@@ -408,10 +394,10 @@ public final class JSONDeserializer
             sourceIQ = new SourcePacketExtension();
             sourceIQ.setSSRC(ssrc);
         }
-        else if (source instanceof JSONObject)
+        else if (source instanceof ObjectNode)
         {
-            JSONObject sourceJSONObject = (JSONObject) source;
-            Object ssrcAttr = sourceJSONObject.get(SourcePacketExtension.SSRC_ATTR_NAME);
+            ObjectNode sourceJSONObject = (ObjectNode) source;
+            JsonNode ssrcAttr = sourceJSONObject.get(SourcePacketExtension.SSRC_ATTR_NAME);
             long ssrc;
 
             try
@@ -425,38 +411,38 @@ public final class JSONDeserializer
             sourceIQ = new SourcePacketExtension();
             sourceIQ.setSSRC(ssrc);
 
-            Object name = sourceJSONObject.get(SourcePacketExtension.NAME_ATTR_NAME);
-            Object videoType = sourceJSONObject.get(SourcePacketExtension.VIDEO_TYPE_ATTR_NAME);
-            Object rid = sourceJSONObject.get(SourcePacketExtension.RID_ATTR_NAME);
-            Object parameters = sourceJSONObject.get(JSONSerializer.PARAMETERS);
-            if (name instanceof String)
+            JsonNode name = sourceJSONObject.get(SourcePacketExtension.NAME_ATTR_NAME);
+            JsonNode videoType = sourceJSONObject.get(SourcePacketExtension.VIDEO_TYPE_ATTR_NAME);
+            JsonNode rid = sourceJSONObject.get(SourcePacketExtension.RID_ATTR_NAME);
+            JsonNode parameters = sourceJSONObject.get(JSONSerializer.PARAMETERS);
+            if (name != null && name.isTextual())
             {
-                sourceIQ.setName((String)name);
+                sourceIQ.setName(name.asText());
             }
-            if (videoType instanceof String)
+            if (videoType != null && videoType.isTextual())
             {
-                sourceIQ.setVideoType((String) videoType);
+                sourceIQ.setVideoType(videoType.asText());
             }
-            if (rid instanceof String)
+            if (rid != null && rid.isTextual())
             {
-                sourceIQ.setRid((String)rid);
+                sourceIQ.setRid(rid.asText());
             }
-            if (parameters instanceof JSONObject)
+            if (parameters instanceof ObjectNode)
             {
-                for (Map.Entry<Object, Object> e
-                    : (Iterable<Map.Entry<Object, Object>>)((JSONObject)parameters).entrySet())
+                ((ObjectNode) parameters).fields().forEachRemaining(e ->
                 {
-                    Object paramName = e.getKey();
-                    Object paramValue = e.getValue();
+                    JsonNode paramValueNode = e.getValue();
+                    String paramName = e.getKey();
+                    String paramValue = paramValueNode.isNull() ? null : paramValueNode.asText();
 
                     if ((paramName != null) || (paramValue != null))
                     {
                         sourceIQ.addParameter(
                             new ParameterPacketExtension(
                                 Objects.toString(paramName, null),
-                                Objects.toString(paramValue, null)));
+                                paramValue));
                     }
-                }
+                });
             }
         }
         else
@@ -467,35 +453,35 @@ public final class JSONDeserializer
     }
 
     public static SourceGroupPacketExtension deserializeSourceGroup(
-            Object sourceGroup)
+            JsonNode sourceGroup)
     {
         SourceGroupPacketExtension sourceGroupIQ;
 
-        if (!(sourceGroup instanceof JSONObject))
+        if (!(sourceGroup instanceof ObjectNode))
         {
             sourceGroupIQ = null;
         }
         else
         {
-            JSONObject sourceGroupJSONObject = (JSONObject) sourceGroup;
+            ObjectNode sourceGroupJSONObject = (ObjectNode) sourceGroup;
 
             // semantics
-            Object semantics = sourceGroupJSONObject
+            JsonNode semantics = sourceGroupJSONObject
                     .get(SourceGroupPacketExtension.SEMANTICS_ATTR_NAME);
 
-            if (semantics instanceof String && ((String) semantics).length() != 0)
+            if (semantics != null && semantics.isTextual() && semantics.asText().length() != 0)
             {
                 // ssrcs
-                Object sourcesObject = sourceGroupJSONObject
+                JsonNode sourcesObject = sourceGroupJSONObject
                         .get(JSONSerializer.SOURCES);
 
-                if (sourcesObject instanceof JSONArray && ((JSONArray) sourcesObject).size() != 0)
+                if (sourcesObject instanceof ArrayNode && ((ArrayNode) sourcesObject).size() != 0)
                 {
-                    JSONArray sourcesJSONArray = (JSONArray) sourcesObject;
+                    ArrayNode sourcesJSONArray = (ArrayNode) sourcesObject;
                     List<SourcePacketExtension> sourcePacketExtensions
                         = new ArrayList<>();
 
-                    for (Object source : sourcesJSONArray)
+                    for (JsonNode source : sourcesJSONArray)
                     {
                         SourcePacketExtension sourcePacketExtension
                                 = deserializeSource(source);
@@ -507,7 +493,7 @@ public final class JSONDeserializer
                     }
 
                     sourceGroupIQ = new SourceGroupPacketExtension();
-                    sourceGroupIQ.setSemantics(Objects.toString(semantics));
+                    sourceGroupIQ.setSemantics(semantics.asText());
                     sourceGroupIQ.addSources(sourcePacketExtensions);
                 }
                 else
@@ -523,20 +509,20 @@ public final class JSONDeserializer
         return sourceGroupIQ;
     }
 
-    public static int deserializeSSRC(Object o)
+    public static long deserializeSSRC(JsonNode o)
         throws NumberFormatException
     {
-        int i = 0;
+        long i = 0;
 
-        if (o != null)
+        if (o != null && !o.isNull())
         {
-            if (o instanceof Number)
+            if (o.isNumber())
             {
-                i = ((Number) o).intValue();
+                i = o.asLong();
             }
             else
             {
-                String s = o.toString();
+                String s = o.asText();
 
                 if (s.startsWith("-"))
                 {
@@ -544,7 +530,7 @@ public final class JSONDeserializer
                 }
                 else
                 {
-                    i = (int) Long.parseLong(s);
+                    i = Long.parseLong(s);
                 }
             }
         }
@@ -552,7 +538,7 @@ public final class JSONDeserializer
     }
 
     public static IceUdpTransportPacketExtension deserializeTransport(
-            JSONObject transport)
+            ObjectNode transport)
     {
         IceUdpTransportPacketExtension transportIQ;
 
@@ -562,15 +548,16 @@ public final class JSONDeserializer
         }
         else
         {
-            Object xmlns = transport.get(JSONSerializer.XMLNS);
-            Object fingerprints = transport.get(JSONSerializer.FINGERPRINTS);
-            Object candidateList = transport.get(JSONSerializer.CANDIDATE_LIST);
-            Object webSocketList = transport.get(JSONSerializer.WEBSOCKET_LIST);
-            Object remoteCandidate
+            JsonNode xmlns = transport.get(JSONSerializer.XMLNS);
+            JsonNode fingerprints = transport.get(JSONSerializer.FINGERPRINTS);
+            JsonNode candidateList = transport.get(JSONSerializer.CANDIDATE_LIST);
+            JsonNode webSocketList = transport.get(JSONSerializer.WEBSOCKET_LIST);
+            JsonNode remoteCandidate
                 = transport.get(RemoteCandidatePacketExtension.ELEMENT);
-            Object rtcpMux = transport.get(IceRtcpmuxPacketExtension.ELEMENT);
+            JsonNode rtcpMux = transport.get(IceRtcpmuxPacketExtension.ELEMENT);
 
-            if (IceUdpTransportPacketExtension.NAMESPACE.equals(xmlns))
+            if (IceUdpTransportPacketExtension.NAMESPACE.equals(
+                    xmlns != null ? xmlns.asText() : null))
             {
                 transportIQ = new IceUdpTransportPacketExtension();
             }
@@ -591,38 +578,42 @@ public final class JSONDeserializer
                 // it's an element
                 transportIQ.removeAttribute(IceRtcpmuxPacketExtension.ELEMENT);
                 // fingerprints
-                if (fingerprints != null)
+                if (fingerprints instanceof ArrayNode)
                 {
                     deserializeFingerprints(
-                            (JSONArray) fingerprints,
+                            (ArrayNode) fingerprints,
                             transportIQ);
                 }
                 // candidateList
-                if (candidateList != null)
+                if (candidateList instanceof ArrayNode)
                 {
                     deserializeCandidates(
-                            (JSONArray) candidateList,
+                            (ArrayNode) candidateList,
                             transportIQ);
                 }
-                if (webSocketList != null)
+                if (webSocketList instanceof ArrayNode)
                 {
                     deserializeWebsockets(
-                        (JSONArray) webSocketList,
+                        (ArrayNode) webSocketList,
                         transportIQ);
                 }
                 // remoteCandidate
-                if (remoteCandidate != null)
+                if (remoteCandidate instanceof ObjectNode)
                 {
                     deserializeCandidate(
-                            (JSONObject) remoteCandidate,
+                            (ObjectNode) remoteCandidate,
                             RemoteCandidatePacketExtension.class,
                             transportIQ);
                 }
                 // rtcpMux
-                if (rtcpMux != null && objectToBoolean(rtcpMux))
+                if (rtcpMux != null)
                 {
-                    transportIQ.addChildExtension(
-                        new IceRtcpmuxPacketExtension());
+                    Boolean b = jsonNodeToBoolean(rtcpMux);
+                    if (b != null && b)
+                    {
+                        transportIQ.addChildExtension(
+                            new IceRtcpmuxPacketExtension());
+                    }
                 }
             }
         }

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONDeserializer.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONDeserializer.java
@@ -152,9 +152,9 @@ public final class JSONDeserializer
         {
             for (JsonNode webSocket : webSockets)
             {
-                deserializeWebsocket(
-                    webSocket.isTextual() ? webSocket.asText() : null,
-                    transportIQ);
+                if (!webSocket.isTextual())
+                    throw new IllegalArgumentException("Expected string websocket, got: " + webSocket.getNodeType());
+                deserializeWebsocket(webSocket.asText(), transportIQ);
             }
         }
     }
@@ -258,8 +258,12 @@ public final class JSONDeserializer
                 ObjectNode rtcpFb = (ObjectNode) iter;
                 JsonNode typeNode = rtcpFb.get(RtcpFbPacketExtension.TYPE_ATTR_NAME);
                 JsonNode subtypeNode = rtcpFb.get(RtcpFbPacketExtension.SUBTYPE_ATTR_NAME);
-                String type = (typeNode != null && typeNode.isTextual()) ? typeNode.asText() : null;
-                String subtype = (subtypeNode != null && subtypeNode.isTextual()) ? subtypeNode.asText() : null;
+                if (typeNode != null && !typeNode.isTextual())
+                    throw new IllegalArgumentException("Expected string rtcp-fb type, got: " + typeNode.getNodeType());
+                if (subtypeNode != null && !subtypeNode.isTextual())
+                    throw new IllegalArgumentException("Expected string rtcp-fb subtype, got: " + subtypeNode.getNodeType());
+                String type = typeNode != null ? typeNode.asText() : null;
+                String subtype = subtypeNode != null ? subtypeNode.asText() : null;
                 if (type != null)
                 {
                     RtcpFbPacketExtension ext = new RtcpFbPacketExtension();
@@ -286,8 +290,12 @@ public final class JSONDeserializer
         {
             JsonNode idNode = headerExtension.get(RTPHdrExtPacketExtension.ID_ATTR_NAME);
             JsonNode uriNode = headerExtension.get(RTPHdrExtPacketExtension.URI_ATTR_NAME);
-            Long id = (idNode != null && idNode.isNumber()) ? idNode.asLong() : null;
-            String uriString = (uriNode != null && uriNode.isTextual()) ? uriNode.asText() : null;
+            if (idNode != null && !idNode.isNumber())
+                throw new IllegalArgumentException("Expected numeric header extension id, got: " + idNode.getNodeType());
+            if (uriNode != null && !uriNode.isTextual())
+                throw new IllegalArgumentException("Expected string header extension uri, got: " + uriNode.getNodeType());
+            Long id = idNode != null ? idNode.asLong() : null;
+            String uriString = uriNode != null ? uriNode.asText() : null;
             URI uri;
             try
             {
@@ -345,15 +353,19 @@ public final class JSONDeserializer
                     payloadType,
                     payloadTypeIQ);
             // parameters
-            if (parameters instanceof ObjectNode)
+            if (parameters != null && !parameters.isNull())
             {
+                if (!(parameters instanceof ObjectNode))
+                    throw new IllegalArgumentException("Expected object for parameters, got: " + parameters.getNodeType());
                 deserializeParameters((ObjectNode) parameters, payloadTypeIQ);
             }
 
             JsonNode rtcpFbs = payloadType.get(JSONSerializer.RTCP_FBS);
 
-            if (rtcpFbs instanceof ArrayNode)
+            if (rtcpFbs != null && !rtcpFbs.isNull())
             {
+                if (!(rtcpFbs instanceof ArrayNode))
+                    throw new IllegalArgumentException("Expected array for rtcp-fbs, got: " + rtcpFbs.getNodeType());
                 deserializeRtcpFbs((ArrayNode) rtcpFbs, payloadTypeIQ);
             }
         }
@@ -427,8 +439,10 @@ public final class JSONDeserializer
             {
                 sourceIQ.setRid(rid.asText());
             }
-            if (parameters instanceof ObjectNode)
+            if (parameters != null && !parameters.isNull())
             {
+                if (!(parameters instanceof ObjectNode))
+                    throw new IllegalArgumentException("Expected object for source parameters, got: " + parameters.getNodeType());
                 ((ObjectNode) parameters).fields().forEachRemaining(e ->
                 {
                     JsonNode paramValueNode = e.getValue();
@@ -447,7 +461,7 @@ public final class JSONDeserializer
         }
         else
         {
-            sourceIQ = null;
+            throw new IllegalArgumentException("Unexpected source node type: " + source.getNodeType());
         }
         return sourceIQ;
     }
@@ -457,9 +471,13 @@ public final class JSONDeserializer
     {
         SourceGroupPacketExtension sourceGroupIQ;
 
-        if (!(sourceGroup instanceof ObjectNode))
+        if (sourceGroup == null || sourceGroup.isNull())
         {
             sourceGroupIQ = null;
+        }
+        else if (!(sourceGroup instanceof ObjectNode))
+        {
+            throw new IllegalArgumentException("Expected object for source group, got: " + sourceGroup.getNodeType());
         }
         else
         {
@@ -469,11 +487,22 @@ public final class JSONDeserializer
             JsonNode semantics = sourceGroupJSONObject
                     .get(SourceGroupPacketExtension.SEMANTICS_ATTR_NAME);
 
-            if (semantics != null && semantics.isTextual() && semantics.asText().length() != 0)
+            if (semantics == null || semantics.isNull() || semantics.asText().length() == 0)
+            {
+                sourceGroupIQ = null;
+            }
+            else if (!semantics.isTextual())
+            {
+                throw new IllegalArgumentException("Expected string semantics, got: " + semantics.getNodeType());
+            }
+            else
             {
                 // ssrcs
                 JsonNode sourcesObject = sourceGroupJSONObject
                         .get(JSONSerializer.SOURCES);
+
+                if (sourcesObject != null && !sourcesObject.isNull() && !(sourcesObject instanceof ArrayNode))
+                    throw new IllegalArgumentException("Expected array for sources, got: " + sourcesObject.getNodeType());
 
                 if (sourcesObject instanceof ArrayNode && ((ArrayNode) sourcesObject).size() != 0)
                 {
@@ -500,10 +529,6 @@ public final class JSONDeserializer
                 {
                     sourceGroupIQ = null;
                 }
-            }
-            else
-            {
-                sourceGroupIQ = null;
             }
         }
         return sourceGroupIQ;
@@ -578,28 +603,30 @@ public final class JSONDeserializer
                 // it's an element
                 transportIQ.removeAttribute(IceRtcpmuxPacketExtension.ELEMENT);
                 // fingerprints
-                if (fingerprints instanceof ArrayNode)
+                if (fingerprints != null && !fingerprints.isNull())
                 {
-                    deserializeFingerprints(
-                            (ArrayNode) fingerprints,
-                            transportIQ);
+                    if (!(fingerprints instanceof ArrayNode))
+                        throw new IllegalArgumentException("Expected array for fingerprints, got: " + fingerprints.getNodeType());
+                    deserializeFingerprints((ArrayNode) fingerprints, transportIQ);
                 }
                 // candidateList
-                if (candidateList instanceof ArrayNode)
+                if (candidateList != null && !candidateList.isNull())
                 {
-                    deserializeCandidates(
-                            (ArrayNode) candidateList,
-                            transportIQ);
+                    if (!(candidateList instanceof ArrayNode))
+                        throw new IllegalArgumentException("Expected array for candidates, got: " + candidateList.getNodeType());
+                    deserializeCandidates((ArrayNode) candidateList, transportIQ);
                 }
-                if (webSocketList instanceof ArrayNode)
+                if (webSocketList != null && !webSocketList.isNull())
                 {
-                    deserializeWebsockets(
-                        (ArrayNode) webSocketList,
-                        transportIQ);
+                    if (!(webSocketList instanceof ArrayNode))
+                        throw new IllegalArgumentException("Expected array for websockets, got: " + webSocketList.getNodeType());
+                    deserializeWebsockets((ArrayNode) webSocketList, transportIQ);
                 }
                 // remoteCandidate
-                if (remoteCandidate instanceof ObjectNode)
+                if (remoteCandidate != null && !remoteCandidate.isNull())
                 {
+                    if (!(remoteCandidate instanceof ObjectNode))
+                        throw new IllegalArgumentException("Expected object for remoteCandidate, got: " + remoteCandidate.getNodeType());
                     deserializeCandidate(
                             (ObjectNode) remoteCandidate,
                             RemoteCandidatePacketExtension.class,

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONDeserializer.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONDeserializer.java
@@ -50,7 +50,7 @@ public final class JSONDeserializer
             ObjectNode jsonObject,
             AbstractPacketExtension abstractPacketExtension)
     {
-        jsonObject.fields().forEachRemaining(e ->
+        jsonObject.properties().forEach(e ->
         {
             String name = e.getKey();
             JsonNode value = e.getValue();
@@ -228,7 +228,7 @@ public final class JSONDeserializer
     {
         if (parameters != null)
         {
-            parameters.fields().forEachRemaining(e ->
+            parameters.properties().forEach(e ->
             {
                 String name = e.getKey();
                 JsonNode valueNode = e.getValue();
@@ -443,7 +443,7 @@ public final class JSONDeserializer
             {
                 if (!(parameters instanceof ObjectNode))
                     throw new IllegalArgumentException("Expected object for source parameters, got: " + parameters.getNodeType());
-                ((ObjectNode) parameters).fields().forEachRemaining(e ->
+                parameters.properties().forEach(e ->
                 {
                     JsonNode paramValueNode = e.getValue();
                     String paramName = e.getKey();

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONSerializer.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri/json/JSONSerializer.java
@@ -18,11 +18,11 @@ package org.jitsi.xmpp.extensions.colibri.json;
 import java.net.*;
 import java.util.*;
 
+import com.fasterxml.jackson.databind.node.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.xmpp.extensions.*;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
-import org.json.simple.*;
 
 /**
  * Implements (utility) functions to serialize instances of
@@ -30,9 +30,10 @@ import org.json.simple.*;
  *
  * @author Lyubomir Marinov
  */
-@SuppressWarnings("unchecked")
 public final class JSONSerializer
 {
+    private static final JsonNodeFactory factory = JsonNodeFactory.instance;
+
     /**
      * The name of the JSON pair which specifies the value of the
      * <tt>candidateList</tt> property of
@@ -79,16 +80,16 @@ public final class JSONSerializer
 
     /**
      * Serializes the attribute values of an <tt>AbstractPacketExtension</tt>
-     * into values of a <tt>JSONObject</tt>.
+     * into values of a <tt>ObjectNode</tt>.
      *
      * @param abstractPacketExtension the <tt>AbstractPacketExtension</tt> whose
      * attribute values are to be serialized into values of <tt>jsonObject</tt>
-     * @param jsonObject the <tt>JSONObject</tt> into which the attribute values
+     * @param jsonObject the <tt>ObjectNode</tt> into which the attribute values
      * of <tt>abstractPacketExtension</tt> are to be serialized
      */
     public static void serializeAbstractPacketExtensionAttributes(
             AbstractPacketExtension abstractPacketExtension,
-            JSONObject jsonObject)
+            ObjectNode jsonObject)
     {
         for (String name : abstractPacketExtension.getAttributeNames())
         {
@@ -102,14 +103,23 @@ public final class JSONSerializer
             if (value instanceof Enum)
                 value = value.toString();
 
-            jsonObject.put(name, value);
+            if (value instanceof String)
+                jsonObject.put(name, (String) value);
+            else if (value instanceof Boolean)
+                jsonObject.put(name, (Boolean) value);
+            else if (value instanceof Integer)
+                jsonObject.put(name, (Integer) value);
+            else if (value instanceof Long)
+                jsonObject.put(name, (Long) value);
+            else if (value != null)
+                jsonObject.put(name, value.toString());
         }
     }
 
-    public static JSONObject serializeCandidate(
+    public static ObjectNode serializeCandidate(
             CandidatePacketExtension candidate)
     {
-        JSONObject candidateJSONObject;
+        ObjectNode candidateJSONObject;
 
         if (candidate == null)
         {
@@ -117,7 +127,7 @@ public final class JSONSerializer
         }
         else
         {
-            candidateJSONObject = new JSONObject();
+            candidateJSONObject = factory.objectNode();
             // attributes
             serializeAbstractPacketExtensionAttributes(
                     candidate,
@@ -126,10 +136,10 @@ public final class JSONSerializer
         return candidateJSONObject;
     }
 
-    public static JSONArray serializeCandidates(
+    public static ArrayNode serializeCandidates(
             Collection<CandidatePacketExtension> candidates)
     {
-        JSONArray candidatesJSONArray;
+        ArrayNode candidatesJSONArray;
 
         if (candidates == null)
         {
@@ -137,17 +147,17 @@ public final class JSONSerializer
         }
         else
         {
-            candidatesJSONArray = new JSONArray();
+            candidatesJSONArray = factory.arrayNode();
             for (CandidatePacketExtension candidate : candidates)
                 candidatesJSONArray.add(serializeCandidate(candidate));
         }
         return candidatesJSONArray;
     }
 
-    public static JSONObject serializeFingerprint(
+    public static ObjectNode serializeFingerprint(
             DtlsFingerprintPacketExtension fingerprint)
     {
-        JSONObject fingerprintJSONObject;
+        ObjectNode fingerprintJSONObject;
 
         if (fingerprint == null)
         {
@@ -157,7 +167,7 @@ public final class JSONSerializer
         {
             String theFingerprint = fingerprint.getFingerprint();
 
-            fingerprintJSONObject = new JSONObject();
+            fingerprintJSONObject = factory.objectNode();
             // fingerprint
             if (theFingerprint != null)
             {
@@ -169,21 +179,22 @@ public final class JSONSerializer
             serializeAbstractPacketExtensionAttributes(
                     fingerprint,
                     fingerprintJSONObject);
-            Object cryptex = fingerprintJSONObject.get(DtlsFingerprintPacketExtension.CRYPTEX_ATTR_NAME);
-            if (cryptex instanceof String)
+            com.fasterxml.jackson.databind.JsonNode cryptex =
+                fingerprintJSONObject.get(DtlsFingerprintPacketExtension.CRYPTEX_ATTR_NAME);
+            if (cryptex != null && cryptex.isTextual())
             {
                 /* Represent cryptex as a boolean. */
                 fingerprintJSONObject.put(DtlsFingerprintPacketExtension.CRYPTEX_ATTR_NAME,
-                    Boolean.parseBoolean((String)cryptex));
+                    Boolean.parseBoolean(cryptex.asText()));
             }
         }
         return fingerprintJSONObject;
     }
 
-    public static JSONArray serializeFingerprints(
+    public static ArrayNode serializeFingerprints(
             Collection<DtlsFingerprintPacketExtension> fingerprints)
     {
-        JSONArray fingerprintsJSONArray;
+        ArrayNode fingerprintsJSONArray;
 
         if (fingerprints == null)
         {
@@ -191,22 +202,22 @@ public final class JSONSerializer
         }
         else
         {
-            fingerprintsJSONArray = new JSONArray();
+            fingerprintsJSONArray = factory.arrayNode();
             for (DtlsFingerprintPacketExtension fingerprint : fingerprints)
                 fingerprintsJSONArray.add(serializeFingerprint(fingerprint));
         }
         return fingerprintsJSONArray;
     }
 
-    public static JSONObject serializeParameters(
+    public static ObjectNode serializeParameters(
             Collection<ParameterPacketExtension> parameters)
     {
         /*
          * A parameter is a key-value pair and the order of the parameters in a
          * payload-type does not appear to matter so a natural representation of
-         * a parameter set is a JSONObject rather than a JSONArray.
+         * a parameter set is a ObjectNode rather than a ArrayNode.
          */
-        JSONObject parametersJSONObject;
+        ObjectNode parametersJSONObject;
 
         if (parameters == null)
         {
@@ -214,25 +225,28 @@ public final class JSONSerializer
         }
         else
         {
-            parametersJSONObject = new JSONObject();
+            parametersJSONObject = factory.objectNode();
             for (ParameterPacketExtension parameter : parameters)
             {
                 String name = parameter.getName();
                 String value = parameter.getValue();
 
                 if ((name != null) || (value != null))
-                    parametersJSONObject.put(name, value);
+                {
+                    /* JSON doesn't allow null keys; use the string "null" to match deserializer convention. */
+                    parametersJSONObject.put(name != null ? name : "null", value);
+                }
             }
         }
         return parametersJSONObject;
     }
 
-    public static JSONArray serializeRtcpFbs(
+    public static ArrayNode serializeRtcpFbs(
             @NotNull Collection<RtcpFbPacketExtension> rtcpFbs)
     {
-        JSONArray rtcpFbsJSON = new JSONArray();
+        ArrayNode rtcpFbsJSON = factory.arrayNode();
         /*
-         * A rtcp-fb is an JSONObject with type / subtype data.
+         * A rtcp-fb is an ObjectNode with type / subtype data.
          * "rtcp-fbs": [ {
                 "type": "ccm",
                 "subtype": "fir"
@@ -249,7 +263,7 @@ public final class JSONSerializer
 
             if (type != null)
             {
-                JSONObject rtcpFbJSON = new JSONObject();
+                ObjectNode rtcpFbJSON = factory.objectNode();
                 rtcpFbJSON.put(RtcpFbPacketExtension.TYPE_ATTR_NAME, type);
                 if (subtype != null)
                 {
@@ -263,10 +277,10 @@ public final class JSONSerializer
         return rtcpFbsJSON;
     }
 
-    public static JSONObject serializePayloadType(
+    public static ObjectNode serializePayloadType(
             PayloadTypePacketExtension payloadType)
     {
-        JSONObject payloadTypeJSONObject;
+        ObjectNode payloadTypeJSONObject;
 
         if (payloadType == null)
         {
@@ -277,7 +291,7 @@ public final class JSONSerializer
             List<ParameterPacketExtension> parameters
                 = payloadType.getParameters();
 
-            payloadTypeJSONObject = new JSONObject();
+            payloadTypeJSONObject = factory.objectNode();
             // attributes
             serializeAbstractPacketExtensionAttributes(
                     payloadType,
@@ -285,7 +299,7 @@ public final class JSONSerializer
             // parameters
             if ((parameters != null) && !parameters.isEmpty())
             {
-                payloadTypeJSONObject.put(
+                payloadTypeJSONObject.set(
                         PARAMETERS,
                         serializeParameters(parameters));
             }
@@ -294,7 +308,7 @@ public final class JSONSerializer
             if ((rtcpFeedbackTypeList != null) &&
                     !rtcpFeedbackTypeList.isEmpty())
             {
-                payloadTypeJSONObject.put(
+                payloadTypeJSONObject.set(
                         RTCP_FBS,
                         serializeRtcpFbs(rtcpFeedbackTypeList));
             }
@@ -302,10 +316,10 @@ public final class JSONSerializer
         return payloadTypeJSONObject;
     }
 
-    public static JSONArray serializePayloadTypes(
+    public static ArrayNode serializePayloadTypes(
             Collection<PayloadTypePacketExtension> payloadTypes)
     {
-        JSONArray payloadTypesJSONArray;
+        ArrayNode payloadTypesJSONArray;
 
         if (payloadTypes == null)
         {
@@ -313,17 +327,17 @@ public final class JSONSerializer
         }
         else
         {
-            payloadTypesJSONArray = new JSONArray();
+            payloadTypesJSONArray = factory.arrayNode();
             for (PayloadTypePacketExtension payloadType : payloadTypes)
                 payloadTypesJSONArray.add(serializePayloadType(payloadType));
         }
         return payloadTypesJSONArray;
     }
 
-    public static JSONObject serializeRtpHdrExt(
+    public static ObjectNode serializeRtpHdrExt(
         RTPHdrExtPacketExtension rtpHdrExt)
     {
-        JSONObject rtpHdrExtJSONObject;
+        ObjectNode rtpHdrExtJSONObject;
 
         if (rtpHdrExt == null)
         {
@@ -331,7 +345,7 @@ public final class JSONSerializer
         }
         else
         {
-            rtpHdrExtJSONObject = new JSONObject();
+            rtpHdrExtJSONObject = factory.objectNode();
 
             String id = rtpHdrExt.getID();
             if (id != null)
@@ -368,10 +382,10 @@ public final class JSONSerializer
         return rtpHdrExtJSONObject;
     }
 
-    public static JSONArray serializeRtpHdrExts(
+    public static ArrayNode serializeRtpHdrExts(
         Collection<RTPHdrExtPacketExtension> rtpHdrExts)
     {
-        JSONArray rtpHdrExtsJSONArray;
+        ArrayNode rtpHdrExtsJSONArray;
 
         if (rtpHdrExts == null)
         {
@@ -379,7 +393,7 @@ public final class JSONSerializer
         }
         else
         {
-            rtpHdrExtsJSONArray = new JSONArray();
+            rtpHdrExtsJSONArray = factory.arrayNode();
             for (RTPHdrExtPacketExtension rtpHdrExt : rtpHdrExts)
                 rtpHdrExtsJSONArray.add(serializeRtpHdrExt(rtpHdrExt));
         }
@@ -404,7 +418,7 @@ public final class JSONSerializer
             return source.getSSRC();
         }
 
-        JSONObject sourceJSONObject = new JSONObject();
+        ObjectNode sourceJSONObject = factory.objectNode();
 
         sourceJSONObject.put(SourcePacketExtension.SSRC_ATTR_NAME, source.getSSRC());
         if (name != null)
@@ -421,7 +435,7 @@ public final class JSONSerializer
         }
         if (!parameters.isEmpty())
         {
-            sourceJSONObject.put(JSONSerializer.PARAMETERS, serializeParameters(parameters));
+            sourceJSONObject.set(JSONSerializer.PARAMETERS, serializeParameters(parameters));
         }
 
         return sourceJSONObject;
@@ -435,19 +449,19 @@ public final class JSONSerializer
                 && sourceGroup.getSources() != null
                 && sourceGroup.getSources().size() != 0)
         {
-            JSONObject sourceGroupJSONObject = new JSONObject();
+            ObjectNode sourceGroupJSONObject = factory.objectNode();
 
             // Add semantics
             sourceGroupJSONObject.put(
                     SourceGroupPacketExtension.SEMANTICS_ATTR_NAME,
-                    JSONValue.escape(sourceGroup.getSemantics()));
+                    sourceGroup.getSemantics());
 
             // Add sources
-            JSONArray ssrcsJSONArray = new JSONArray();
+            ArrayNode ssrcsJSONArray = factory.arrayNode();
             for (SourcePacketExtension source : sourceGroup.getSources())
                 ssrcsJSONArray.add(source.getSSRC());
 
-            sourceGroupJSONObject.put(SOURCES, ssrcsJSONArray);
+            sourceGroupJSONObject.set(SOURCES, ssrcsJSONArray);
 
             return sourceGroupJSONObject;
         }
@@ -457,10 +471,10 @@ public final class JSONSerializer
         }
     }
 
-    public static JSONArray serializeSourceGroups(
+    public static ArrayNode serializeSourceGroups(
             Collection<SourceGroupPacketExtension> sourceGroups)
     {
-        JSONArray sourceGroupsJSONArray;
+        ArrayNode sourceGroupsJSONArray;
 
         if (sourceGroups == null || sourceGroups.size() == 0)
         {
@@ -468,17 +482,23 @@ public final class JSONSerializer
         }
         else
         {
-            sourceGroupsJSONArray = new JSONArray();
+            sourceGroupsJSONArray = factory.arrayNode();
             for (SourceGroupPacketExtension sourceGroup : sourceGroups)
-                sourceGroupsJSONArray.add(serializeSourceGroup(sourceGroup));
+            {
+                Object serialized = serializeSourceGroup(sourceGroup);
+                if (serialized instanceof ObjectNode)
+                    sourceGroupsJSONArray.add((ObjectNode) serialized);
+                else if (serialized == null)
+                    sourceGroupsJSONArray.addNull();
+            }
         }
         return sourceGroupsJSONArray;
     }
 
-    public static JSONArray serializeSources(
+    public static ArrayNode serializeSources(
             Collection<SourcePacketExtension> sources)
     {
-        JSONArray sourcesJSONArray;
+        ArrayNode sourcesJSONArray;
 
         if (sources == null)
         {
@@ -486,17 +506,27 @@ public final class JSONSerializer
         }
         else
         {
-            sourcesJSONArray = new JSONArray();
+            sourcesJSONArray = factory.arrayNode();
             for (SourcePacketExtension source : sources)
-                sourcesJSONArray.add(serializeSource(source));
+            {
+                Object serialized = serializeSource(source);
+                if (serialized instanceof ObjectNode)
+                    sourcesJSONArray.add((ObjectNode) serialized);
+                else if (serialized instanceof Long)
+                    sourcesJSONArray.add((Long) serialized);
+                else if (serialized instanceof Integer)
+                    sourcesJSONArray.add((Integer) serialized);
+                else if (serialized == null)
+                    sourcesJSONArray.addNull();
+            }
         }
         return sourcesJSONArray;
     }
 
-    public static JSONObject serializeTransport(
+    public static ObjectNode serializeTransport(
             IceUdpTransportPacketExtension transport)
     {
-        JSONObject jsonObject;
+        ObjectNode jsonObject;
 
         if (transport == null)
         {
@@ -517,7 +547,7 @@ public final class JSONSerializer
                 = transport.getRemoteCandidate();
             boolean rtcpMux = transport.isRtcpMux();
 
-            jsonObject = new JSONObject();
+            jsonObject = factory.objectNode();
             // xmlns
             if (xmlns != null)
                 jsonObject.put(XMLNS, xmlns);
@@ -526,27 +556,27 @@ public final class JSONSerializer
             // fingerprints
             if ((fingerprints != null) && !fingerprints.isEmpty())
             {
-                jsonObject.put(
+                jsonObject.set(
                         FINGERPRINTS,
                         serializeFingerprints(fingerprints));
             }
             // candidateList
             if ((candidateList != null) && !candidateList.isEmpty())
             {
-                jsonObject.put(
+                jsonObject.set(
                         CANDIDATE_LIST,
                         serializeCandidates(candidateList));
             }
             // remoteCandidate
             if (remoteCandidate != null)
             {
-                jsonObject.put(
+                jsonObject.set(
                         remoteCandidate.getElementName(),
                         serializeCandidate(remoteCandidate));
             }
             if ( (webSocketList != null) && (!webSocketList.isEmpty()) )
             {
-                jsonObject.put(
+                jsonObject.set(
                         WEBSOCKET_LIST,
                         serializeWebSockets(webSocketList));
             }
@@ -574,10 +604,10 @@ public final class JSONSerializer
         }
     }
 
-    private static JSONArray serializeWebSockets(
+    private static ArrayNode serializeWebSockets(
              List<WebSocketPacketExtension> webSocketList)
     {
-        JSONArray webSocketsJSONArray;
+        ArrayNode webSocketsJSONArray;
 
         if (webSocketList == null)
         {
@@ -585,7 +615,7 @@ public final class JSONSerializer
         }
         else
         {
-            webSocketsJSONArray = new JSONArray();
+            webSocketsJSONArray = factory.arrayNode();
             for (WebSocketPacketExtension webSocket : webSocketList)
                 webSocketsJSONArray.add(serializeWebSocket(webSocket));
         }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONDeserializer.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONDeserializer.kt
@@ -45,27 +45,25 @@ object Colibri2JSONDeserializer {
     private fun deserializeMedia(media: ObjectNode): Media {
         return Media.getBuilder().apply {
             media[Media.TYPE_ATTR_NAME]?.let {
-                if (it.isTextual) {
-                    setType(MediaType.parseString(it.asText()))
-                }
+                require(it.isTextual) { "Expected string for ${Media.TYPE_ATTR_NAME}, got ${it.nodeType}" }
+                setType(MediaType.parseString(it.asText()))
             }
 
             media[Colibri2JSONSerializer.PAYLOAD_TYPES]?.let { payloadTypes ->
-                if (payloadTypes is ArrayNode) {
-                    JSONDeserializer.deserializePayloadTypes(payloadTypes).forEach { addPayloadType(it) }
-                }
+                require(payloadTypes is ArrayNode) { "Expected array for payloadTypes, got ${payloadTypes.nodeType}" }
+                JSONDeserializer.deserializePayloadTypes(payloadTypes).forEach { addPayloadType(it) }
             }
 
             media[Colibri2JSONSerializer.RTP_HEADER_EXTS]?.let { rtpHdrExts ->
-                if (rtpHdrExts is ArrayNode) {
-                    JSONDeserializer.deserializeHeaderExtensions(rtpHdrExts).forEach { addRtpHdrExt(it) }
-                }
+                require(rtpHdrExts is ArrayNode) { "Expected array for rtpHdrExts, got ${rtpHdrExts.nodeType}" }
+                JSONDeserializer.deserializeHeaderExtensions(rtpHdrExts).forEach { addRtpHdrExt(it) }
             }
 
             media[ExtmapAllowMixedPacketExtension.ELEMENT]?.let {
-                if (it.isBoolean) {
-                    setExtmapAllowMixed(ExtmapAllowMixedPacketExtension())
+                require(it.isBoolean) {
+                    "Expected boolean for ${ExtmapAllowMixedPacketExtension.ELEMENT}, got ${it.nodeType}"
                 }
+                setExtmapAllowMixed(ExtmapAllowMixedPacketExtension())
             }
         }.build()
     }
@@ -73,15 +71,13 @@ object Colibri2JSONDeserializer {
     private fun deserializeSctp(sctp: ObjectNode): Sctp {
         return Sctp.Builder().apply {
             sctp[Sctp.ROLE_ATTR_NAME]?.let {
-                if (it.isTextual) {
-                    setRole(Sctp.Role.parseString(it.asText()))
-                }
+                require(it.isTextual) { "Expected string for ${Sctp.ROLE_ATTR_NAME}, got ${it.nodeType}" }
+                setRole(Sctp.Role.parseString(it.asText()))
             }
 
             sctp[Sctp.PORT_ATTR_NAME]?.let {
-                if (it.isNumber) {
-                    setPort(it.asInt())
-                }
+                require(it.isNumber) { "Expected number for ${Sctp.PORT_ATTR_NAME}, got ${it.nodeType}" }
+                setPort(it.asInt())
             }
         }.build()
     }
@@ -89,27 +85,29 @@ object Colibri2JSONDeserializer {
     private fun deserializeTransport(transport: ObjectNode): Transport {
         return Transport.getBuilder().apply {
             transport[Transport.ICE_CONTROLLING_ATTR_NAME]?.let {
-                if (it.isBoolean) {
-                    setIceControlling(it.asBoolean())
+                require(it.isBoolean) {
+                    "Expected boolean for ${Transport.ICE_CONTROLLING_ATTR_NAME}, got ${it.nodeType}"
                 }
+                setIceControlling(it.asBoolean())
             }
 
             transport[Transport.USE_UNIQUE_PORT_ATTR_NAME]?.let {
-                if (it.isBoolean) {
-                    setUseUniquePort(it.asBoolean())
+                require(it.isBoolean) {
+                    "Expected boolean for ${Transport.USE_UNIQUE_PORT_ATTR_NAME}, got ${it.nodeType}"
                 }
+                setUseUniquePort(it.asBoolean())
             }
 
             transport[IceUdpTransportPacketExtension.ELEMENT]?.let {
-                if (it is ObjectNode) {
-                    setIceUdpExtension(JSONDeserializer.deserializeTransport(it))
+                require(it is ObjectNode) {
+                    "Expected object for ${IceUdpTransportPacketExtension.ELEMENT}, got ${it.nodeType}"
                 }
+                setIceUdpExtension(JSONDeserializer.deserializeTransport(it))
             }
 
             transport[Sctp.ELEMENT]?.let {
-                if (it is ObjectNode) {
-                    setSctp(deserializeSctp(it))
-                }
+                require(it is ObjectNode) { "Expected object for ${Sctp.ELEMENT}, got ${it.nodeType}" }
+                setSctp(deserializeSctp(it))
             }
         }.build()
     }
@@ -117,27 +115,23 @@ object Colibri2JSONDeserializer {
     private fun deserializeMediaSource(mediaSource: ObjectNode): MediaSource {
         return MediaSource.getBuilder().apply {
             mediaSource[MediaSource.TYPE_ATTR_NAME]?.let {
-                if (it.isTextual) {
-                    setType(MediaType.parseString(it.asText()))
-                }
+                require(it.isTextual) { "Expected string for ${MediaSource.TYPE_ATTR_NAME}, got ${it.nodeType}" }
+                setType(MediaType.parseString(it.asText()))
             }
 
             mediaSource[MediaSource.ID_NAME]?.let {
-                if (it.isTextual) {
-                    setId(it.asText())
-                }
+                require(it.isTextual) { "Expected string for ${MediaSource.ID_NAME}, got ${it.nodeType}" }
+                setId(it.asText())
             }
 
             mediaSource[Colibri2JSONSerializer.SOURCES]?.let { sources ->
-                if (sources is ArrayNode) {
-                    sources.forEach { addSource(JSONDeserializer.deserializeSource(it)) }
-                }
+                require(sources is ArrayNode) { "Expected array for sources, got ${sources.nodeType}" }
+                sources.forEach { addSource(JSONDeserializer.deserializeSource(it)) }
             }
 
             mediaSource[Colibri2JSONSerializer.SOURCE_GROUPS]?.let { sourceGroups ->
-                if (sourceGroups is ArrayNode) {
-                    sourceGroups.forEach { addSsrcGroup(JSONDeserializer.deserializeSourceGroup(it)) }
-                }
+                require(sourceGroups is ArrayNode) { "Expected array for sourceGroups, got ${sourceGroups.nodeType}" }
+                sourceGroups.forEach { addSsrcGroup(JSONDeserializer.deserializeSourceGroup(it)) }
             }
         }.build()
     }
@@ -145,9 +139,8 @@ object Colibri2JSONDeserializer {
     private fun deserializeMedias(medias: ArrayNode): Collection<Media> {
         return ArrayList<Media>().apply {
             medias.forEach {
-                if (it is ObjectNode) {
-                    add(deserializeMedia(it))
-                }
+                require(it is ObjectNode) { "Expected object for media element, got ${it.nodeType}" }
+                add(deserializeMedia(it))
             }
         }
     }
@@ -155,9 +148,8 @@ object Colibri2JSONDeserializer {
     private fun deserializeSources(sources: ArrayNode): Sources {
         return Sources.getBuilder().apply {
             sources.forEach {
-                if (it is ObjectNode) {
-                    addMediaSource(deserializeMediaSource(it))
-                }
+                require(it is ObjectNode) { "Expected object for source element, got ${it.nodeType}" }
+                addMediaSource(deserializeMediaSource(it))
             }
         }.build()
     }
@@ -167,39 +159,37 @@ object Colibri2JSONDeserializer {
         builder: AbstractConferenceEntity.Builder
     ) {
         entity[AbstractConferenceEntity.ID_ATTR_NAME]?.let {
-            if (it.isTextual) {
-                builder.setId(it.asText())
-            }
+            require(it.isTextual) { "Expected string for ${AbstractConferenceEntity.ID_ATTR_NAME}, got ${it.nodeType}" }
+            builder.setId(it.asText())
         }
 
         entity[AbstractConferenceEntity.CREATE_ATTR_NAME]?.let {
-            if (it.isBoolean) {
-                builder.setCreate(it.asBoolean())
+            require(it.isBoolean) {
+                "Expected boolean for ${AbstractConferenceEntity.CREATE_ATTR_NAME}, got ${it.nodeType}"
             }
+            builder.setCreate(it.asBoolean())
         }
 
         entity[AbstractConferenceEntity.EXPIRE_ATTR_NAME]?.let {
-            if (it.isBoolean) {
-                builder.setExpire(it.asBoolean())
+            require(it.isBoolean) {
+                "Expected boolean for ${AbstractConferenceEntity.EXPIRE_ATTR_NAME}, got ${it.nodeType}"
             }
+            builder.setExpire(it.asBoolean())
         }
 
         entity[Colibri2JSONSerializer.MEDIA_LIST]?.let { medias ->
-            if (medias is ArrayNode) {
-                deserializeMedias(medias).forEach { builder.addMedia(it) }
-            }
+            require(medias is ArrayNode) { "Expected array for mediaList, got ${medias.nodeType}" }
+            deserializeMedias(medias).forEach { builder.addMedia(it) }
         }
 
         entity[Transport.ELEMENT]?.let {
-            if (it is ObjectNode) {
-                builder.setTransport(deserializeTransport(it))
-            }
+            require(it is ObjectNode) { "Expected object for ${Transport.ELEMENT}, got ${it.nodeType}" }
+            builder.setTransport(deserializeTransport(it))
         }
 
         entity[Sources.ELEMENT]?.let {
-            if (it is ArrayNode) {
-                builder.setSources(deserializeSources(it))
-            }
+            require(it is ArrayNode) { "Expected array for ${Sources.ELEMENT}, got ${it.nodeType}" }
+            builder.setSources(deserializeSources(it))
         }
     }
 
@@ -212,17 +202,16 @@ object Colibri2JSONDeserializer {
         val audio = forceMute[ForceMute.AUDIO_ATTR_NAME]
         val video = forceMute[ForceMute.VIDEO_ATTR_NAME]
 
+        if (audio != null) {
+            require(audio.isBoolean) { "Expected boolean for ${ForceMute.AUDIO_ATTR_NAME}, got ${audio.nodeType}" }
+        }
+        if (video != null) {
+            require(video.isBoolean) { "Expected boolean for ${ForceMute.VIDEO_ATTR_NAME}, got ${video.nodeType}" }
+        }
+
         return ForceMute(
-            if (audio != null && audio.isBoolean) {
-                audio.asBoolean()
-            } else {
-                ForceMute.AUDIO_DEFAULT
-            },
-            if (video != null && video.isBoolean) {
-                video.asBoolean()
-            } else {
-                ForceMute.VIDEO_DEFAULT
-            }
+            audio?.asBoolean() ?: ForceMute.AUDIO_DEFAULT,
+            video?.asBoolean() ?: ForceMute.VIDEO_DEFAULT
         )
     }
 
@@ -231,36 +220,36 @@ object Colibri2JSONDeserializer {
             deserializeAbstractConferenceEntityToBuilder(endpoint, this)
 
             endpoint[Colibri2Endpoint.STATS_ID_ATTR_NAME]?.let {
-                if (it.isTextual) {
-                    setStatsId(it.asText())
+                require(it.isTextual) {
+                    "Expected string for ${Colibri2Endpoint.STATS_ID_ATTR_NAME}, got ${it.nodeType}"
                 }
+                setStatsId(it.asText())
             }
 
             endpoint[Colibri2Endpoint.MUC_ROLE_ATTR_NAME]?.let {
-                if (it.isTextual) {
-                    setMucRole(MUCRole.fromString(it.asText()))
+                require(it.isTextual) {
+                    "Expected string for ${Colibri2Endpoint.MUC_ROLE_ATTR_NAME}, got ${it.nodeType}"
                 }
+                setMucRole(MUCRole.fromString(it.asText()))
             }
 
             endpoint[ForceMute.ELEMENT]?.let {
-                if (it is ObjectNode) {
-                    setForceMute(deserializeForceMute(it))
-                }
+                require(it is ObjectNode) { "Expected object for ${ForceMute.ELEMENT}, got ${it.nodeType}" }
+                setForceMute(deserializeForceMute(it))
             }
 
             endpoint[InitialLastN.ELEMENT]?.let {
-                if (it is ObjectNode) {
-                    setInitialLastN(deserializeInitialLastN(it))
-                }
+                require(it is ObjectNode) { "Expected object for ${InitialLastN.ELEMENT}, got ${it.nodeType}" }
+                setInitialLastN(deserializeInitialLastN(it))
             }
 
             endpoint[Colibri2JSONSerializer.CAPABILITIES_LIST]?.let { capabilities ->
-                if (capabilities is ArrayNode) {
-                    capabilities.forEach {
-                        if (it.isTextual) {
-                            addCapability(it.asText())
-                        }
-                    }
+                require(capabilities is ArrayNode) {
+                    "Expected array for capabilitiesList, got ${capabilities.nodeType}"
+                }
+                capabilities.forEach {
+                    require(it.isTextual) { "Expected string capability, got ${it.nodeType}" }
+                    addCapability(it.asText())
                 }
             }
         }.build()
@@ -271,19 +260,17 @@ object Colibri2JSONDeserializer {
             deserializeAbstractConferenceEntityToBuilder(relay, this)
 
             relay[Colibri2Relay.MESH_ID_ATTR_NAME]?.let {
-                if (it.isTextual) {
-                    setMeshId(it.asText())
-                }
+                require(it.isTextual) { "Expected string for ${Colibri2Relay.MESH_ID_ATTR_NAME}, got ${it.nodeType}" }
+                setMeshId(it.asText())
             }
 
             relay[Colibri2JSONSerializer.ENDPOINTS]?.let { endpoints ->
-                if (endpoints is ArrayNode) {
-                    setEndpoints(
-                        Endpoints.getBuilder().apply {
-                            deserializeEndpoints(endpoints).forEach { addEndpoint(it) }
-                        }.build()
-                    )
-                }
+                require(endpoints is ArrayNode) { "Expected array for endpoints, got ${endpoints.nodeType}" }
+                setEndpoints(
+                    Endpoints.getBuilder().apply {
+                        deserializeEndpoints(endpoints).forEach { addEndpoint(it) }
+                    }.build()
+                )
             }
         }.build()
     }
@@ -291,9 +278,8 @@ object Colibri2JSONDeserializer {
     private fun deserializeEndpoints(endpoints: ArrayNode): Collection<Colibri2Endpoint> {
         return ArrayList<Colibri2Endpoint>().apply {
             endpoints.forEach {
-                if (it is ObjectNode) {
-                    add(deserializeEndpoint(it))
-                }
+                require(it is ObjectNode) { "Expected object for endpoint element, got ${it.nodeType}" }
+                add(deserializeEndpoint(it))
             }
         }
     }
@@ -301,9 +287,8 @@ object Colibri2JSONDeserializer {
     private fun deserializeRelays(relays: ArrayNode): Collection<Colibri2Relay> {
         return ArrayList<Colibri2Relay>().apply {
             relays.forEach {
-                if (it is ObjectNode) {
-                    add(deserializeRelay(it))
-                }
+                require(it is ObjectNode) { "Expected object for relay element, got ${it.nodeType}" }
+                add(deserializeRelay(it))
             }
         }
     }
@@ -312,16 +297,14 @@ object Colibri2JSONDeserializer {
         modification: ObjectNode,
         builder: AbstractConferenceModificationIQ.Builder<*>
     ) {
-        modification[Colibri2JSONSerializer.ENDPOINTS].let { endpoints ->
-            if (endpoints is ArrayNode) {
-                deserializeEndpoints(endpoints).forEach { builder.addConferenceEntity(it) }
-            }
+        modification[Colibri2JSONSerializer.ENDPOINTS]?.let { endpoints ->
+            require(endpoints is ArrayNode) { "Expected array for endpoints, got ${endpoints.nodeType}" }
+            deserializeEndpoints(endpoints).forEach { builder.addConferenceEntity(it) }
         }
 
-        modification[Colibri2JSONSerializer.RELAYS].let { relays ->
-            if (relays is ArrayNode) {
-                deserializeRelays(relays).forEach { builder.addConferenceEntity(it) }
-            }
+        modification[Colibri2JSONSerializer.RELAYS]?.let { relays ->
+            require(relays is ArrayNode) { "Expected array for relays, got ${relays.nodeType}" }
+            deserializeRelays(relays).forEach { builder.addConferenceEntity(it) }
         }
     }
 
@@ -331,83 +314,93 @@ object Colibri2JSONDeserializer {
             deserializeAbstractConferenceModificationToBuilder(conferenceModify, this)
 
             conferenceModify[ConferenceModifyIQ.MEETING_ID_ATTR_NAME]?.let {
-                if (it.isTextual) {
-                    setMeetingId(it.asText())
+                require(it.isTextual) {
+                    "Expected string for ${ConferenceModifyIQ.MEETING_ID_ATTR_NAME}, got ${it.nodeType}"
                 }
+                setMeetingId(it.asText())
             }
 
             conferenceModify[ConferenceModifyIQ.NAME_ATTR_NAME]?.let {
-                if (it.isTextual) {
-                    setConferenceName(it.asText())
-                }
+                require(it.isTextual) { "Expected string for ${ConferenceModifyIQ.NAME_ATTR_NAME}, got ${it.nodeType}" }
+                setConferenceName(it.asText())
             }
 
             conferenceModify[ConferenceModifyIQ.CREATE_ATTR_NAME]?.let {
-                if (it.isBoolean) {
-                    setCreate(it.asBoolean())
+                require(it.isBoolean) {
+                    "Expected boolean for ${ConferenceModifyIQ.CREATE_ATTR_NAME}, got ${it.nodeType}"
                 }
+                setCreate(it.asBoolean())
             }
 
             conferenceModify[ConferenceModifyIQ.EXPIRE_ATTR_NAME]?.let {
-                if (it.isBoolean) {
-                    setExpire(it.asBoolean())
+                require(it.isBoolean) {
+                    "Expected boolean for ${ConferenceModifyIQ.EXPIRE_ATTR_NAME}, got ${it.nodeType}"
                 }
+                setExpire(it.asBoolean())
             }
 
             conferenceModify[ConferenceModifyIQ.RTCSTATS_ENABLED_ATTR_NAME]?.let {
-                if (it.isBoolean) {
-                    setRtcstatsEnabled(it.asBoolean())
+                require(it.isBoolean) {
+                    "Expected boolean for ${ConferenceModifyIQ.RTCSTATS_ENABLED_ATTR_NAME}, got ${it.nodeType}"
                 }
+                setRtcstatsEnabled(it.asBoolean())
             }
 
             conferenceModify[Connects.ELEMENT]?.let {
-                if (it is ArrayNode) {
-                    var added = false
-                    it.forEach { connect ->
-                        if (connect is ObjectNode) {
-                            val connectObj = Connect(
-                                URI(connect[Connect.URL_ATTR_NAME]!!.asText()),
-                                protocol = Connect.Protocols.valueOf(
-                                    connect[Connect.PROTOCOL_ATTR_NAME]!!.asText().uppercase()
-                                ),
-                                type = Connect.Types.valueOf(
-                                    connect[Connect.TYPE_ATTR_NAME]!!.asText().uppercase()
-                                ),
-                                audio = connect[Connect.AUDIO_ATTR_NAME]?.asBoolean() ?: false,
-                                video = connect[Connect.VIDEO_ATTR_NAME]?.asBoolean() ?: false
-                            )
+                require(it is ArrayNode) { "Expected array for ${Connects.ELEMENT}, got ${it.nodeType}" }
+                var added = false
+                it.forEach { connect ->
+                    require(connect is ObjectNode) { "Expected object for connect element, got ${connect.nodeType}" }
+                    val connectObj = Connect(
+                        URI(connect[Connect.URL_ATTR_NAME]!!.asText()),
+                        protocol = Connect.Protocols.valueOf(
+                            connect[Connect.PROTOCOL_ATTR_NAME]!!.asText().uppercase()
+                        ),
+                        type = Connect.Types.valueOf(
+                            connect[Connect.TYPE_ATTR_NAME]!!.asText().uppercase()
+                        ),
+                        audio = connect[Connect.AUDIO_ATTR_NAME]?.asBoolean() ?: false,
+                        video = connect[Connect.VIDEO_ATTR_NAME]?.asBoolean() ?: false
+                    )
 
-                            // Deserialize HTTP headers
-                            connect["headers"]?.let { headers ->
-                                if (headers is ObjectNode) {
-                                    headers.fields().forEach { e ->
-                                        if (e.value.isTextual) {
-                                            connectObj.addHttpHeader(e.key, e.value.asText())
-                                        }
-                                    }
-                                }
+                    // Deserialize HTTP headers
+                    connect["headers"]?.let { headers ->
+                        require(headers is ObjectNode) { "Expected object for headers, got ${headers.nodeType}" }
+                        headers.properties().forEach { e ->
+                            require(e.value.isTextual) {
+                                "Expected string header value for ${e.key}, got ${e.value.nodeType}"
                             }
-
-                            // Deserialize ping
-                            connect["ping"]?.let { ping ->
-                                if (ping is ObjectNode) {
-                                    val interval = ping[Connect.Ping.INTERVAL_ATTR_NAME]
-                                        ?.takeIf { it.isNumber }?.asInt()
-                                    val timeout = ping[Connect.Ping.TIMEOUT_ATTR_NAME]
-                                        ?.takeIf { it.isNumber }?.asInt()
-                                    if (interval != null && timeout != null) {
-                                        connectObj.setPing(interval, timeout)
-                                    }
-                                }
-                            }
-
-                            addConnect(connectObj)
-                            added = true
+                            connectObj.addHttpHeader(e.key, e.value.asText())
                         }
                     }
-                    // An empty array is distinct from no value specified.
-                    if (!added) setEmptyConnects()
+
+                    // Deserialize ping
+                    connect["ping"]?.let { ping ->
+                        require(ping is ObjectNode) { "Expected object for ping, got ${ping.nodeType}" }
+                        val interval = ping[Connect.Ping.INTERVAL_ATTR_NAME]
+                            ?.also {
+                                require(it.isNumber) {
+                                    "Expected number for ${Connect.Ping.INTERVAL_ATTR_NAME}, got ${it.nodeType}"
+                                }
+                            }
+                            ?.asInt()
+                        val timeout = ping[Connect.Ping.TIMEOUT_ATTR_NAME]
+                            ?.also {
+                                require(it.isNumber) {
+                                    "Expected number for ${Connect.Ping.TIMEOUT_ATTR_NAME}, got ${it.nodeType}"
+                                }
+                            }
+                            ?.asInt()
+                        if (interval != null && timeout != null) {
+                            connectObj.setPing(interval, timeout)
+                        }
+                    }
+
+                    addConnect(connectObj)
+                    added = true
                 }
+                // An empty array is distinct from no value specified.
+                if (!added) setEmptyConnects()
             }
         }
     }
@@ -417,9 +410,8 @@ object Colibri2JSONDeserializer {
         return ConferenceModifiedIQ.builder("id").apply {
             deserializeAbstractConferenceModificationToBuilder(conferenceModified, this)
             conferenceModified[Sources.ELEMENT]?.let {
-                if (it is ArrayNode) {
-                    setSources(deserializeSources(it))
-                }
+                require(it is ArrayNode) { "Expected array for ${Sources.ELEMENT}, got ${it.nodeType}" }
+                setSources(deserializeSources(it))
             }
         }
     }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONDeserializer.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONDeserializer.kt
@@ -15,6 +15,8 @@
  */
 package org.jitsi.xmpp.extensions.colibri2.json
 
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.jitsi.utils.MediaType
 import org.jitsi.xmpp.extensions.colibri.json.JSONDeserializer
 import org.jitsi.xmpp.extensions.colibri2.AbstractConferenceEntity
@@ -36,126 +38,124 @@ import org.jitsi.xmpp.extensions.colibri2.Transport
 import org.jitsi.xmpp.extensions.jingle.ExtmapAllowMixedPacketExtension
 import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
 import org.jivesoftware.smackx.muc.MUCRole
-import org.json.simple.JSONArray
-import org.json.simple.JSONObject
 import java.lang.IllegalArgumentException
 import java.net.URI
 
 object Colibri2JSONDeserializer {
-    private fun deserializeMedia(media: JSONObject): Media {
+    private fun deserializeMedia(media: ObjectNode): Media {
         return Media.getBuilder().apply {
             media[Media.TYPE_ATTR_NAME]?.let {
-                if (it is String) {
-                    setType(MediaType.parseString(it))
+                if (it.isTextual) {
+                    setType(MediaType.parseString(it.asText()))
                 }
             }
 
             media[Colibri2JSONSerializer.PAYLOAD_TYPES]?.let { payloadTypes ->
-                if (payloadTypes is JSONArray) {
+                if (payloadTypes is ArrayNode) {
                     JSONDeserializer.deserializePayloadTypes(payloadTypes).forEach { addPayloadType(it) }
                 }
             }
 
             media[Colibri2JSONSerializer.RTP_HEADER_EXTS]?.let { rtpHdrExts ->
-                if (rtpHdrExts is JSONArray) {
+                if (rtpHdrExts is ArrayNode) {
                     JSONDeserializer.deserializeHeaderExtensions(rtpHdrExts).forEach { addRtpHdrExt(it) }
                 }
             }
 
             media[ExtmapAllowMixedPacketExtension.ELEMENT]?.let {
-                if (it is Boolean) {
+                if (it.isBoolean) {
                     setExtmapAllowMixed(ExtmapAllowMixedPacketExtension())
                 }
             }
         }.build()
     }
 
-    private fun deserializeSctp(sctp: JSONObject): Sctp {
+    private fun deserializeSctp(sctp: ObjectNode): Sctp {
         return Sctp.Builder().apply {
             sctp[Sctp.ROLE_ATTR_NAME]?.let {
-                if (it is String) {
-                    setRole(Sctp.Role.parseString(it))
+                if (it.isTextual) {
+                    setRole(Sctp.Role.parseString(it.asText()))
                 }
             }
 
             sctp[Sctp.PORT_ATTR_NAME]?.let {
-                if (it is Number) {
-                    setPort(it.toInt())
+                if (it.isNumber) {
+                    setPort(it.asInt())
                 }
             }
         }.build()
     }
 
-    private fun deserializeTransport(transport: JSONObject): Transport {
+    private fun deserializeTransport(transport: ObjectNode): Transport {
         return Transport.getBuilder().apply {
             transport[Transport.ICE_CONTROLLING_ATTR_NAME]?.let {
-                if (it is Boolean) {
-                    setIceControlling(it)
+                if (it.isBoolean) {
+                    setIceControlling(it.asBoolean())
                 }
             }
 
             transport[Transport.USE_UNIQUE_PORT_ATTR_NAME]?.let {
-                if (it is Boolean) {
-                    setUseUniquePort(it)
+                if (it.isBoolean) {
+                    setUseUniquePort(it.asBoolean())
                 }
             }
 
             transport[IceUdpTransportPacketExtension.ELEMENT]?.let {
-                if (it is JSONObject) {
+                if (it is ObjectNode) {
                     setIceUdpExtension(JSONDeserializer.deserializeTransport(it))
                 }
             }
 
             transport[Sctp.ELEMENT]?.let {
-                if (it is JSONObject) {
+                if (it is ObjectNode) {
                     setSctp(deserializeSctp(it))
                 }
             }
         }.build()
     }
 
-    private fun deserializeMediaSource(mediaSource: JSONObject): MediaSource {
+    private fun deserializeMediaSource(mediaSource: ObjectNode): MediaSource {
         return MediaSource.getBuilder().apply {
             mediaSource[MediaSource.TYPE_ATTR_NAME]?.let {
-                if (it is String) {
-                    setType(MediaType.parseString(it))
+                if (it.isTextual) {
+                    setType(MediaType.parseString(it.asText()))
                 }
             }
 
             mediaSource[MediaSource.ID_NAME]?.let {
-                if (it is String) {
-                    setId(it)
+                if (it.isTextual) {
+                    setId(it.asText())
                 }
             }
 
             mediaSource[Colibri2JSONSerializer.SOURCES]?.let { sources ->
-                if (sources is JSONArray) {
+                if (sources is ArrayNode) {
                     sources.forEach { addSource(JSONDeserializer.deserializeSource(it)) }
                 }
             }
 
             mediaSource[Colibri2JSONSerializer.SOURCE_GROUPS]?.let { sourceGroups ->
-                if (sourceGroups is JSONArray) {
+                if (sourceGroups is ArrayNode) {
                     sourceGroups.forEach { addSsrcGroup(JSONDeserializer.deserializeSourceGroup(it)) }
                 }
             }
         }.build()
     }
 
-    private fun deserializeMedias(medias: JSONArray): Collection<Media> {
+    private fun deserializeMedias(medias: ArrayNode): Collection<Media> {
         return ArrayList<Media>().apply {
             medias.forEach {
-                if (it is JSONObject) {
+                if (it is ObjectNode) {
                     add(deserializeMedia(it))
                 }
             }
         }
     }
 
-    private fun deserializeSources(sources: JSONArray): Sources {
+    private fun deserializeSources(sources: ArrayNode): Sources {
         return Sources.getBuilder().apply {
             sources.forEach {
-                if (it is JSONObject) {
+                if (it is ObjectNode) {
                     addMediaSource(deserializeMediaSource(it))
                 }
             }
@@ -163,102 +163,102 @@ object Colibri2JSONDeserializer {
     }
 
     private fun deserializeAbstractConferenceEntityToBuilder(
-        entity: JSONObject,
+        entity: ObjectNode,
         builder: AbstractConferenceEntity.Builder
     ) {
         entity[AbstractConferenceEntity.ID_ATTR_NAME]?.let {
-            if (it is String) {
-                builder.setId(it)
+            if (it.isTextual) {
+                builder.setId(it.asText())
             }
         }
 
         entity[AbstractConferenceEntity.CREATE_ATTR_NAME]?.let {
-            if (it is Boolean) {
-                builder.setCreate(it)
+            if (it.isBoolean) {
+                builder.setCreate(it.asBoolean())
             }
         }
 
         entity[AbstractConferenceEntity.EXPIRE_ATTR_NAME]?.let {
-            if (it is Boolean) {
-                builder.setExpire(it)
+            if (it.isBoolean) {
+                builder.setExpire(it.asBoolean())
             }
         }
 
         entity[Colibri2JSONSerializer.MEDIA_LIST]?.let { medias ->
-            if (medias is JSONArray) {
+            if (medias is ArrayNode) {
                 deserializeMedias(medias).forEach { builder.addMedia(it) }
             }
         }
 
         entity[Transport.ELEMENT]?.let {
-            if (it is JSONObject) {
+            if (it is ObjectNode) {
                 builder.setTransport(deserializeTransport(it))
             }
         }
 
         entity[Sources.ELEMENT]?.let {
-            if (it is JSONArray) {
+            if (it is ArrayNode) {
                 builder.setSources(deserializeSources(it))
             }
         }
     }
 
-    private fun deserializeInitialLastN(initialLastN: JSONObject) = InitialLastN(
-        initialLastN[InitialLastN.VALUE_ATTR_NAME]?.toString()?.toInt()
+    private fun deserializeInitialLastN(initialLastN: ObjectNode) = InitialLastN(
+        initialLastN[InitialLastN.VALUE_ATTR_NAME]?.takeIf { it.isNumber }?.asInt()
             ?: throw IllegalArgumentException("Invalid 'value'")
     )
 
-    private fun deserializeForceMute(forceMute: JSONObject): ForceMute {
+    private fun deserializeForceMute(forceMute: ObjectNode): ForceMute {
         val audio = forceMute[ForceMute.AUDIO_ATTR_NAME]
         val video = forceMute[ForceMute.VIDEO_ATTR_NAME]
 
         return ForceMute(
-            if (audio is Boolean) {
-                audio
+            if (audio != null && audio.isBoolean) {
+                audio.asBoolean()
             } else {
                 ForceMute.AUDIO_DEFAULT
             },
-            if (video is Boolean) {
-                video
+            if (video != null && video.isBoolean) {
+                video.asBoolean()
             } else {
                 ForceMute.VIDEO_DEFAULT
             }
         )
     }
 
-    private fun deserializeEndpoint(endpoint: JSONObject): Colibri2Endpoint {
+    private fun deserializeEndpoint(endpoint: ObjectNode): Colibri2Endpoint {
         return Colibri2Endpoint.getBuilder().apply {
             deserializeAbstractConferenceEntityToBuilder(endpoint, this)
 
             endpoint[Colibri2Endpoint.STATS_ID_ATTR_NAME]?.let {
-                if (it is String) {
-                    setStatsId(it)
+                if (it.isTextual) {
+                    setStatsId(it.asText())
                 }
             }
 
             endpoint[Colibri2Endpoint.MUC_ROLE_ATTR_NAME]?.let {
-                if (it is String) {
-                    setMucRole(MUCRole.fromString(it))
+                if (it.isTextual) {
+                    setMucRole(MUCRole.fromString(it.asText()))
                 }
             }
 
             endpoint[ForceMute.ELEMENT]?.let {
-                if (it is JSONObject) {
+                if (it is ObjectNode) {
                     setForceMute(deserializeForceMute(it))
                 }
             }
 
             endpoint[InitialLastN.ELEMENT]?.let {
-                if (it is JSONObject) {
+                if (it is ObjectNode) {
                     setInitialLastN(deserializeInitialLastN(it))
                 }
             }
 
             endpoint[Colibri2JSONSerializer.CAPABILITIES_LIST]?.let { capabilities ->
-                if (capabilities is JSONArray) {
+                if (capabilities is ArrayNode) {
                     capabilities.forEach {
-                        if (it is String) {
-                            addCapability(it)
+                        if (it.isTextual) {
+                            addCapability(it.asText())
                         }
                     }
                 }
@@ -266,18 +266,18 @@ object Colibri2JSONDeserializer {
         }.build()
     }
 
-    private fun deserializeRelay(relay: JSONObject): Colibri2Relay {
+    private fun deserializeRelay(relay: ObjectNode): Colibri2Relay {
         return Colibri2Relay.getBuilder().apply {
             deserializeAbstractConferenceEntityToBuilder(relay, this)
 
             relay[Colibri2Relay.MESH_ID_ATTR_NAME]?.let {
-                if (it is String) {
-                    setMeshId(it)
+                if (it.isTextual) {
+                    setMeshId(it.asText())
                 }
             }
 
             relay[Colibri2JSONSerializer.ENDPOINTS]?.let { endpoints ->
-                if (endpoints is JSONArray) {
+                if (endpoints is ArrayNode) {
                     setEndpoints(
                         Endpoints.getBuilder().apply {
                             deserializeEndpoints(endpoints).forEach { addEndpoint(it) }
@@ -288,20 +288,20 @@ object Colibri2JSONDeserializer {
         }.build()
     }
 
-    private fun deserializeEndpoints(endpoints: JSONArray): Collection<Colibri2Endpoint> {
+    private fun deserializeEndpoints(endpoints: ArrayNode): Collection<Colibri2Endpoint> {
         return ArrayList<Colibri2Endpoint>().apply {
             endpoints.forEach {
-                if (it is JSONObject) {
+                if (it is ObjectNode) {
                     add(deserializeEndpoint(it))
                 }
             }
         }
     }
 
-    private fun deserializeRelays(relays: JSONArray): Collection<Colibri2Relay> {
+    private fun deserializeRelays(relays: ArrayNode): Collection<Colibri2Relay> {
         return ArrayList<Colibri2Relay>().apply {
             relays.forEach {
-                if (it is JSONObject) {
+                if (it is ObjectNode) {
                     add(deserializeRelay(it))
                 }
             }
@@ -309,80 +309,80 @@ object Colibri2JSONDeserializer {
     }
 
     private fun deserializeAbstractConferenceModificationToBuilder(
-        modification: JSONObject,
+        modification: ObjectNode,
         builder: AbstractConferenceModificationIQ.Builder<*>
     ) {
         modification[Colibri2JSONSerializer.ENDPOINTS].let { endpoints ->
-            if (endpoints is JSONArray) {
+            if (endpoints is ArrayNode) {
                 deserializeEndpoints(endpoints).forEach { builder.addConferenceEntity(it) }
             }
         }
 
         modification[Colibri2JSONSerializer.RELAYS].let { relays ->
-            if (relays is JSONArray) {
+            if (relays is ArrayNode) {
                 deserializeRelays(relays).forEach { builder.addConferenceEntity(it) }
             }
         }
     }
 
     @JvmStatic
-    fun deserializeConferenceModify(conferenceModify: JSONObject): ConferenceModifyIQ.Builder {
+    fun deserializeConferenceModify(conferenceModify: ObjectNode): ConferenceModifyIQ.Builder {
         return ConferenceModifyIQ.builder("id").apply {
             deserializeAbstractConferenceModificationToBuilder(conferenceModify, this)
 
             conferenceModify[ConferenceModifyIQ.MEETING_ID_ATTR_NAME]?.let {
-                if (it is String) {
-                    setMeetingId(it)
+                if (it.isTextual) {
+                    setMeetingId(it.asText())
                 }
             }
 
             conferenceModify[ConferenceModifyIQ.NAME_ATTR_NAME]?.let {
-                if (it is String) {
-                    setConferenceName(it)
+                if (it.isTextual) {
+                    setConferenceName(it.asText())
                 }
             }
 
             conferenceModify[ConferenceModifyIQ.CREATE_ATTR_NAME]?.let {
-                if (it is Boolean) {
-                    setCreate(it)
+                if (it.isBoolean) {
+                    setCreate(it.asBoolean())
                 }
             }
 
             conferenceModify[ConferenceModifyIQ.EXPIRE_ATTR_NAME]?.let {
-                if (it is Boolean) {
-                    setExpire(it)
+                if (it.isBoolean) {
+                    setExpire(it.asBoolean())
                 }
             }
 
             conferenceModify[ConferenceModifyIQ.RTCSTATS_ENABLED_ATTR_NAME]?.let {
-                if (it is Boolean) {
-                    setRtcstatsEnabled(it)
+                if (it.isBoolean) {
+                    setRtcstatsEnabled(it.asBoolean())
                 }
             }
 
             conferenceModify[Connects.ELEMENT]?.let {
-                if (it is JSONArray) {
+                if (it is ArrayNode) {
                     var added = false
                     it.forEach { connect ->
-                        if (connect is JSONObject) {
+                        if (connect is ObjectNode) {
                             val connectObj = Connect(
-                                URI(connect[Connect.URL_ATTR_NAME] as String),
+                                URI(connect[Connect.URL_ATTR_NAME]!!.asText()),
                                 protocol = Connect.Protocols.valueOf(
-                                    (connect[Connect.PROTOCOL_ATTR_NAME] as String).uppercase()
+                                    connect[Connect.PROTOCOL_ATTR_NAME]!!.asText().uppercase()
                                 ),
                                 type = Connect.Types.valueOf(
-                                    (connect[Connect.TYPE_ATTR_NAME] as String).uppercase()
+                                    connect[Connect.TYPE_ATTR_NAME]!!.asText().uppercase()
                                 ),
-                                audio = connect[Connect.AUDIO_ATTR_NAME]?.toString()?.toBoolean() ?: false,
-                                video = connect[Connect.VIDEO_ATTR_NAME]?.toString()?.toBoolean() ?: false
+                                audio = connect[Connect.AUDIO_ATTR_NAME]?.asBoolean() ?: false,
+                                video = connect[Connect.VIDEO_ATTR_NAME]?.asBoolean() ?: false
                             )
 
                             // Deserialize HTTP headers
                             connect["headers"]?.let { headers ->
-                                if (headers is JSONObject) {
-                                    headers.forEach { (name, value) ->
-                                        if (name is String && value is String) {
-                                            connectObj.addHttpHeader(name, value)
+                                if (headers is ObjectNode) {
+                                    headers.fields().forEach { e ->
+                                        if (e.value.isTextual) {
+                                            connectObj.addHttpHeader(e.key, e.value.asText())
                                         }
                                     }
                                 }
@@ -390,9 +390,11 @@ object Colibri2JSONDeserializer {
 
                             // Deserialize ping
                             connect["ping"]?.let { ping ->
-                                if (ping is JSONObject) {
-                                    val interval = (ping[Connect.Ping.INTERVAL_ATTR_NAME] as? Number)?.toInt()
-                                    val timeout = (ping[Connect.Ping.TIMEOUT_ATTR_NAME] as? Number)?.toInt()
+                                if (ping is ObjectNode) {
+                                    val interval = ping[Connect.Ping.INTERVAL_ATTR_NAME]
+                                        ?.takeIf { it.isNumber }?.asInt()
+                                    val timeout = ping[Connect.Ping.TIMEOUT_ATTR_NAME]
+                                        ?.takeIf { it.isNumber }?.asInt()
                                     if (interval != null && timeout != null) {
                                         connectObj.setPing(interval, timeout)
                                     }
@@ -411,11 +413,11 @@ object Colibri2JSONDeserializer {
     }
 
     @JvmStatic
-    fun deserializeConferenceModified(conferenceModified: JSONObject): ConferenceModifiedIQ.Builder {
+    fun deserializeConferenceModified(conferenceModified: ObjectNode): ConferenceModifiedIQ.Builder {
         return ConferenceModifiedIQ.builder("id").apply {
             deserializeAbstractConferenceModificationToBuilder(conferenceModified, this)
             conferenceModified[Sources.ELEMENT]?.let {
-                if (it is JSONArray) {
+                if (it is ArrayNode) {
                     setSources(deserializeSources(it))
                 }
             }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializer.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializer.kt
@@ -15,6 +15,9 @@
  */
 package org.jitsi.xmpp.extensions.colibri2.json
 
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
 import org.jitsi.xmpp.extensions.colibri.json.JSONSerializer
 import org.jitsi.xmpp.extensions.colibri2.AbstractConferenceEntity
@@ -38,8 +41,8 @@ import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
 import org.jitsi.xmpp.extensions.jingle.PayloadTypePacketExtension
 import org.jitsi.xmpp.extensions.jingle.RTPHdrExtPacketExtension
 import org.jitsi.xmpp.extensions.jingle.SourceGroupPacketExtension
-import org.json.simple.JSONArray
-import org.json.simple.JSONObject
+
+private val jsonMapper = jacksonObjectMapper()
 
 object Colibri2JSONSerializer {
     /**
@@ -90,28 +93,28 @@ object Colibri2JSONSerializer {
      */
     const val SOURCES = SourcePacketExtension.ELEMENT + "s"
 
-    private fun serializeMedia(media: Media): JSONObject {
-        return JSONObject().apply {
+    private fun serializeMedia(media: Media): ObjectNode {
+        return jsonMapper.createObjectNode().apply {
             put(Media.TYPE_ATTR_NAME, media.type.toString())
             if (media.payloadTypes.isNotEmpty()) {
-                put(PAYLOAD_TYPES, JSONSerializer.serializePayloadTypes(media.payloadTypes))
+                set<ObjectNode>(PAYLOAD_TYPES, JSONSerializer.serializePayloadTypes(media.payloadTypes))
             }
             if (media.rtpHdrExts.isNotEmpty()) {
-                put(RTP_HEADER_EXTS, JSONSerializer.serializeRtpHdrExts(media.rtpHdrExts))
+                set<ObjectNode>(RTP_HEADER_EXTS, JSONSerializer.serializeRtpHdrExts(media.rtpHdrExts))
             }
             media.extmapAllowMixed?.let { put(ExtmapAllowMixedPacketExtension.ELEMENT, true) }
         }
     }
 
-    private fun serializeSctp(sctp: Sctp): JSONObject {
-        return JSONObject().apply {
+    private fun serializeSctp(sctp: Sctp): ObjectNode {
+        return jsonMapper.createObjectNode().apply {
             sctp.port?.let { put(Sctp.PORT_ATTR_NAME, it) }
-            sctp.role?.let { put(Sctp.ROLE_ATTR_NAME, it) }
+            sctp.role?.let { put(Sctp.ROLE_ATTR_NAME, it.toString()) }
         }
     }
 
-    private fun serializeTransport(transport: Transport): JSONObject {
-        return JSONObject().apply {
+    private fun serializeTransport(transport: Transport): ObjectNode {
+        return jsonMapper.createObjectNode().apply {
             if (transport.iceControlling != Transport.ICE_CONTROLLING_DEFAULT) {
                 put(Transport.ICE_CONTROLLING_ATTR_NAME, transport.iceControlling)
             }
@@ -119,41 +122,41 @@ object Colibri2JSONSerializer {
                 put(Transport.USE_UNIQUE_PORT_ATTR_NAME, transport.useUniquePort)
             }
             transport.iceUdpTransport?.let {
-                put(IceUdpTransportPacketExtension.ELEMENT, JSONSerializer.serializeTransport(it))
+                set<ObjectNode>(IceUdpTransportPacketExtension.ELEMENT, JSONSerializer.serializeTransport(it))
             }
             transport.sctp?.let {
-                put(Sctp.ELEMENT, serializeSctp(it))
+                set<ObjectNode>(Sctp.ELEMENT, serializeSctp(it))
             }
         }
     }
 
-    private fun serializeMediaSource(source: MediaSource): JSONObject {
-        return JSONObject().apply {
+    private fun serializeMediaSource(source: MediaSource): ObjectNode {
+        return jsonMapper.createObjectNode().apply {
             put(MediaSource.TYPE_ATTR_NAME, source.type.toString())
             put(MediaSource.ID_NAME, source.id)
             if (source.sources.isNotEmpty()) {
-                put(SOURCES, JSONSerializer.serializeSources(source.sources))
+                set<ObjectNode>(SOURCES, JSONSerializer.serializeSources(source.sources))
             }
             if (source.ssrcGroups.isNotEmpty()) {
-                put(SOURCE_GROUPS, JSONSerializer.serializeSourceGroups(source.ssrcGroups))
+                set<ObjectNode>(SOURCE_GROUPS, JSONSerializer.serializeSourceGroups(source.ssrcGroups))
             }
         }
     }
 
-    private fun serializeMedias(medias: Collection<Media>): JSONArray {
-        return JSONArray().apply {
+    private fun serializeMedias(medias: Collection<Media>): ArrayNode {
+        return jsonMapper.createArrayNode().apply {
             medias.forEach { add(serializeMedia(it)) }
         }
     }
 
-    private fun serializeSources(sources: Sources): JSONArray {
-        return JSONArray().apply {
+    private fun serializeSources(sources: Sources): ArrayNode {
+        return jsonMapper.createArrayNode().apply {
             sources.mediaSources.forEach { add(serializeMediaSource(it)) }
         }
     }
 
-    private fun serializeAbstractConferenceEntity(entity: AbstractConferenceEntity): JSONObject {
-        return JSONObject().apply {
+    private fun serializeAbstractConferenceEntity(entity: AbstractConferenceEntity): ObjectNode {
+        return jsonMapper.createObjectNode().apply {
             put(AbstractConferenceEntity.ID_ATTR_NAME, entity.id)
 
             if (entity.create != AbstractConferenceEntity.CREATE_DEFAULT) {
@@ -165,75 +168,75 @@ object Colibri2JSONSerializer {
             }
 
             if (entity.media.isNotEmpty()) {
-                put(MEDIA_LIST, serializeMedias(entity.media))
+                set<ObjectNode>(MEDIA_LIST, serializeMedias(entity.media))
             }
 
-            entity.transport?.let { put(Transport.ELEMENT, serializeTransport(it)) }
+            entity.transport?.let { set<ObjectNode>(Transport.ELEMENT, serializeTransport(it)) }
 
-            entity.sources?.let { put(Sources.ELEMENT, serializeSources(it)) }
+            entity.sources?.let { set<ObjectNode>(Sources.ELEMENT, serializeSources(it)) }
         }
     }
 
-    private fun serializeForceMute(forceMute: ForceMute): JSONObject {
-        return JSONObject().apply {
+    private fun serializeForceMute(forceMute: ForceMute): ObjectNode {
+        return jsonMapper.createObjectNode().apply {
             put(ForceMute.AUDIO_ATTR_NAME, forceMute.audio)
             put(ForceMute.VIDEO_ATTR_NAME, forceMute.video)
         }
     }
 
-    private fun serializeInitialLastN(initialLastN: InitialLastN) = JSONObject().apply {
+    private fun serializeInitialLastN(initialLastN: InitialLastN) = jsonMapper.createObjectNode().apply {
         put(InitialLastN.VALUE_ATTR_NAME, initialLastN.value)
     }
 
-    private fun serializeCapabilities(capabilities: Collection<Capability>): JSONArray {
-        return JSONArray().apply {
+    private fun serializeCapabilities(capabilities: Collection<Capability>): ArrayNode {
+        return jsonMapper.createArrayNode().apply {
             capabilities.forEach { add(it.name) }
         }
     }
 
-    private fun serializeEndpoint(endpoint: Colibri2Endpoint): JSONObject {
+    private fun serializeEndpoint(endpoint: Colibri2Endpoint): ObjectNode {
         return serializeAbstractConferenceEntity(endpoint).apply {
             endpoint.statsId?.apply { put(Colibri2Endpoint.STATS_ID_ATTR_NAME, this) }
             endpoint.mucRole?.apply { put(Colibri2Endpoint.MUC_ROLE_ATTR_NAME, this.toString()) }
-            endpoint.forceMute?.apply { put(ForceMute.ELEMENT, serializeForceMute(this)) }
-            endpoint.initialLastN?.apply { put(InitialLastN.ELEMENT, serializeInitialLastN(this)) }
+            endpoint.forceMute?.apply { set<ObjectNode>(ForceMute.ELEMENT, serializeForceMute(this)) }
+            endpoint.initialLastN?.apply { set<ObjectNode>(InitialLastN.ELEMENT, serializeInitialLastN(this)) }
             if (endpoint.capabilities.isNotEmpty()) {
-                put(CAPABILITIES_LIST, serializeCapabilities(endpoint.capabilities))
+                set<ObjectNode>(CAPABILITIES_LIST, serializeCapabilities(endpoint.capabilities))
             }
         }
     }
 
-    private fun serializeRelay(relay: Colibri2Relay): JSONObject {
+    private fun serializeRelay(relay: Colibri2Relay): ObjectNode {
         return serializeAbstractConferenceEntity(relay).apply {
             relay.meshId?.apply { put(Colibri2Relay.MESH_ID_ATTR_NAME, this) }
-            relay.endpoints?.let { put(ENDPOINTS, serializeEndpoints(it.endpoints)) }
+            relay.endpoints?.let { set<ObjectNode>(ENDPOINTS, serializeEndpoints(it.endpoints)) }
         }
     }
 
-    private fun serializeEndpoints(endpoints: Collection<Colibri2Endpoint>): JSONArray {
-        return JSONArray().apply {
+    private fun serializeEndpoints(endpoints: Collection<Colibri2Endpoint>): ArrayNode {
+        return jsonMapper.createArrayNode().apply {
             endpoints.forEach { add(serializeEndpoint(it)) }
         }
     }
 
-    private fun serializeRelays(relays: Collection<Colibri2Relay>): JSONArray {
-        return JSONArray().apply {
+    private fun serializeRelays(relays: Collection<Colibri2Relay>): ArrayNode {
+        return jsonMapper.createArrayNode().apply {
             relays.forEach { add(serializeRelay(it)) }
         }
     }
 
-    private fun serializeAbstractConferenceModificationIQ(iq: AbstractConferenceModificationIQ<*>): JSONObject {
-        return JSONObject().apply {
+    private fun serializeAbstractConferenceModificationIQ(iq: AbstractConferenceModificationIQ<*>): ObjectNode {
+        return jsonMapper.createObjectNode().apply {
             if (iq.endpoints.isNotEmpty()) {
-                put(ENDPOINTS, serializeEndpoints(iq.endpoints))
+                set<ObjectNode>(ENDPOINTS, serializeEndpoints(iq.endpoints))
             }
             if (iq.relays.isNotEmpty()) {
-                put(RELAYS, serializeRelays(iq.relays))
+                set<ObjectNode>(RELAYS, serializeRelays(iq.relays))
             }
         }
     }
 
-    private fun serializeConnect(connect: Connect) = JSONObject().apply {
+    private fun serializeConnect(connect: Connect) = jsonMapper.createObjectNode().apply {
         put(Connect.URL_ATTR_NAME, connect.url.toString())
         put(Connect.PROTOCOL_ATTR_NAME, connect.protocol.toString().lowercase())
         put(Connect.TYPE_ATTR_NAME, connect.type.toString().lowercase())
@@ -243,28 +246,28 @@ object Colibri2JSONSerializer {
         // Serialize HTTP headers
         val headers = connect.getHttpHeaders()
         if (headers.isNotEmpty()) {
-            val headersObj = JSONObject()
+            val headersObj = jsonMapper.createObjectNode()
             headers.forEach { header ->
-                headersObj[header.name] = header.value
+                headersObj.put(header.name, header.value)
             }
-            put("headers", headersObj)
+            set<ObjectNode>("headers", headersObj)
         }
 
         // Serialize ping
         connect.getPing()?.let { ping ->
-            val pingObj = JSONObject()
-            pingObj[Connect.Ping.INTERVAL_ATTR_NAME] = ping.interval
-            pingObj[Connect.Ping.TIMEOUT_ATTR_NAME] = ping.timeout
-            put("ping", pingObj)
+            val pingObj = jsonMapper.createObjectNode()
+            pingObj.put(Connect.Ping.INTERVAL_ATTR_NAME, ping.interval)
+            pingObj.put(Connect.Ping.TIMEOUT_ATTR_NAME, ping.timeout)
+            set<ObjectNode>("ping", pingObj)
         }
     }
 
-    private fun serializeConnects(connects: Connects) = JSONArray().apply {
+    private fun serializeConnects(connects: Connects) = jsonMapper.createArrayNode().apply {
         connects.getConnects().forEach { add(serializeConnect(it)) }
     }
 
     @JvmStatic
-    fun serializeConferenceModify(iq: ConferenceModifyIQ): JSONObject {
+    fun serializeConferenceModify(iq: ConferenceModifyIQ): ObjectNode {
         return serializeAbstractConferenceModificationIQ(iq).apply {
             if (iq.create != ConferenceModifyIQ.CREATE_DEFAULT) {
                 put(ConferenceModifyIQ.CREATE_ATTR_NAME, iq.create)
@@ -279,7 +282,7 @@ object Colibri2JSONSerializer {
             }
 
             iq.connects?.let {
-                put(Connects.ELEMENT, serializeConnects(it))
+                set<ObjectNode>(Connects.ELEMENT, serializeConnects(it))
             }
 
             put(ConferenceModifyIQ.MEETING_ID_ATTR_NAME, iq.meetingId)
@@ -289,9 +292,9 @@ object Colibri2JSONSerializer {
     }
 
     @JvmStatic
-    fun serializeConferenceModified(iq: ConferenceModifiedIQ): JSONObject {
+    fun serializeConferenceModified(iq: ConferenceModifiedIQ): ObjectNode {
         return serializeAbstractConferenceModificationIQ(iq).apply {
-            iq.sources?.let { put(Sources.ELEMENT, serializeSources(it)) }
+            iq.sources?.let { set<ObjectNode>(Sources.ELEMENT, serializeSources(it)) }
         }
     }
 }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializer.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializer.kt
@@ -16,8 +16,8 @@
 package org.jitsi.xmpp.extensions.colibri2.json
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.jitsi.xmpp.extensions.colibri.SourcePacketExtension
 import org.jitsi.xmpp.extensions.colibri.json.JSONSerializer
 import org.jitsi.xmpp.extensions.colibri2.AbstractConferenceEntity
@@ -41,8 +41,6 @@ import org.jitsi.xmpp.extensions.jingle.IceUdpTransportPacketExtension
 import org.jitsi.xmpp.extensions.jingle.PayloadTypePacketExtension
 import org.jitsi.xmpp.extensions.jingle.RTPHdrExtPacketExtension
 import org.jitsi.xmpp.extensions.jingle.SourceGroupPacketExtension
-
-private val jsonMapper = jacksonObjectMapper()
 
 object Colibri2JSONSerializer {
     /**
@@ -94,7 +92,7 @@ object Colibri2JSONSerializer {
     const val SOURCES = SourcePacketExtension.ELEMENT + "s"
 
     private fun serializeMedia(media: Media): ObjectNode {
-        return jsonMapper.createObjectNode().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             put(Media.TYPE_ATTR_NAME, media.type.toString())
             if (media.payloadTypes.isNotEmpty()) {
                 set<ObjectNode>(PAYLOAD_TYPES, JSONSerializer.serializePayloadTypes(media.payloadTypes))
@@ -107,14 +105,14 @@ object Colibri2JSONSerializer {
     }
 
     private fun serializeSctp(sctp: Sctp): ObjectNode {
-        return jsonMapper.createObjectNode().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             sctp.port?.let { put(Sctp.PORT_ATTR_NAME, it) }
             sctp.role?.let { put(Sctp.ROLE_ATTR_NAME, it.toString()) }
         }
     }
 
     private fun serializeTransport(transport: Transport): ObjectNode {
-        return jsonMapper.createObjectNode().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             if (transport.iceControlling != Transport.ICE_CONTROLLING_DEFAULT) {
                 put(Transport.ICE_CONTROLLING_ATTR_NAME, transport.iceControlling)
             }
@@ -131,7 +129,7 @@ object Colibri2JSONSerializer {
     }
 
     private fun serializeMediaSource(source: MediaSource): ObjectNode {
-        return jsonMapper.createObjectNode().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             put(MediaSource.TYPE_ATTR_NAME, source.type.toString())
             put(MediaSource.ID_NAME, source.id)
             if (source.sources.isNotEmpty()) {
@@ -144,19 +142,19 @@ object Colibri2JSONSerializer {
     }
 
     private fun serializeMedias(medias: Collection<Media>): ArrayNode {
-        return jsonMapper.createArrayNode().apply {
+        return JsonNodeFactory.instance.arrayNode().apply {
             medias.forEach { add(serializeMedia(it)) }
         }
     }
 
     private fun serializeSources(sources: Sources): ArrayNode {
-        return jsonMapper.createArrayNode().apply {
+        return JsonNodeFactory.instance.arrayNode().apply {
             sources.mediaSources.forEach { add(serializeMediaSource(it)) }
         }
     }
 
     private fun serializeAbstractConferenceEntity(entity: AbstractConferenceEntity): ObjectNode {
-        return jsonMapper.createObjectNode().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             put(AbstractConferenceEntity.ID_ATTR_NAME, entity.id)
 
             if (entity.create != AbstractConferenceEntity.CREATE_DEFAULT) {
@@ -178,18 +176,18 @@ object Colibri2JSONSerializer {
     }
 
     private fun serializeForceMute(forceMute: ForceMute): ObjectNode {
-        return jsonMapper.createObjectNode().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             put(ForceMute.AUDIO_ATTR_NAME, forceMute.audio)
             put(ForceMute.VIDEO_ATTR_NAME, forceMute.video)
         }
     }
 
-    private fun serializeInitialLastN(initialLastN: InitialLastN) = jsonMapper.createObjectNode().apply {
+    private fun serializeInitialLastN(initialLastN: InitialLastN) = JsonNodeFactory.instance.objectNode().apply {
         put(InitialLastN.VALUE_ATTR_NAME, initialLastN.value)
     }
 
     private fun serializeCapabilities(capabilities: Collection<Capability>): ArrayNode {
-        return jsonMapper.createArrayNode().apply {
+        return JsonNodeFactory.instance.arrayNode().apply {
             capabilities.forEach { add(it.name) }
         }
     }
@@ -214,19 +212,19 @@ object Colibri2JSONSerializer {
     }
 
     private fun serializeEndpoints(endpoints: Collection<Colibri2Endpoint>): ArrayNode {
-        return jsonMapper.createArrayNode().apply {
+        return JsonNodeFactory.instance.arrayNode().apply {
             endpoints.forEach { add(serializeEndpoint(it)) }
         }
     }
 
     private fun serializeRelays(relays: Collection<Colibri2Relay>): ArrayNode {
-        return jsonMapper.createArrayNode().apply {
+        return JsonNodeFactory.instance.arrayNode().apply {
             relays.forEach { add(serializeRelay(it)) }
         }
     }
 
     private fun serializeAbstractConferenceModificationIQ(iq: AbstractConferenceModificationIQ<*>): ObjectNode {
-        return jsonMapper.createObjectNode().apply {
+        return JsonNodeFactory.instance.objectNode().apply {
             if (iq.endpoints.isNotEmpty()) {
                 set<ObjectNode>(ENDPOINTS, serializeEndpoints(iq.endpoints))
             }
@@ -236,7 +234,7 @@ object Colibri2JSONSerializer {
         }
     }
 
-    private fun serializeConnect(connect: Connect) = jsonMapper.createObjectNode().apply {
+    private fun serializeConnect(connect: Connect) = JsonNodeFactory.instance.objectNode().apply {
         put(Connect.URL_ATTR_NAME, connect.url.toString())
         put(Connect.PROTOCOL_ATTR_NAME, connect.protocol.toString().lowercase())
         put(Connect.TYPE_ATTR_NAME, connect.type.toString().lowercase())
@@ -246,7 +244,7 @@ object Colibri2JSONSerializer {
         // Serialize HTTP headers
         val headers = connect.getHttpHeaders()
         if (headers.isNotEmpty()) {
-            val headersObj = jsonMapper.createObjectNode()
+            val headersObj = JsonNodeFactory.instance.objectNode()
             headers.forEach { header ->
                 headersObj.put(header.name, header.value)
             }
@@ -255,14 +253,14 @@ object Colibri2JSONSerializer {
 
         // Serialize ping
         connect.getPing()?.let { ping ->
-            val pingObj = jsonMapper.createObjectNode()
+            val pingObj = JsonNodeFactory.instance.objectNode()
             pingObj.put(Connect.Ping.INTERVAL_ATTR_NAME, ping.interval)
             pingObj.put(Connect.Ping.TIMEOUT_ATTR_NAME, ping.timeout)
             set<ObjectNode>("ping", pingObj)
         }
     }
 
-    private fun serializeConnects(connects: Connects) = jsonMapper.createArrayNode().apply {
+    private fun serializeConnects(connects: Connects) = JsonNodeFactory.instance.arrayNode().apply {
         connects.getConnects().forEach { add(serializeConnect(it)) }
     }
 

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializerTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializerTest.kt
@@ -15,6 +15,8 @@
  */
 package org.jitsi.xmpp.extensions.colibri2.json
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.asClue
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.core.spec.style.ShouldSpec
@@ -28,8 +30,6 @@ import org.jitsi.xmpp.extensions.colibri2.ConferenceModifyIQ
 import org.jitsi.xmpp.extensions.colibri2.IqProviderUtils
 import org.jivesoftware.smack.packet.IQ
 import org.jivesoftware.smack.util.PacketParserUtils
-import org.json.simple.JSONObject
-import org.json.simple.parser.JSONParser
 import org.xmlunit.builder.DiffBuilder
 import java.lang.IllegalStateException
 import kotlin.reflect.KClass
@@ -50,7 +50,7 @@ class Colibri2JSONSerializerTest : ShouldSpec() {
                     is ConferenceModifyIQ -> Colibri2JSONSerializer.serializeConferenceModify(iq)
                     is ConferenceModifiedIQ -> Colibri2JSONSerializer.serializeConferenceModified(iq)
                     else -> throw IllegalStateException("Bad type in test")
-                }.toJSONString()
+                }.toString()
 
                 should("To JSON: ${it.name}") {
                     json.shouldEqualJson(it.json)
@@ -60,15 +60,14 @@ class Colibri2JSONSerializerTest : ShouldSpec() {
 
         context("deserializing JSON") {
             expectedMappings.forEach {
-                val parser = JSONParser()
-                val json = parser.parse(it.json)
-                json.shouldBeInstanceOf<JSONObject>()
+                val json = jacksonObjectMapper().readTree(it.json)
+                json.shouldBeInstanceOf<ObjectNode>()
 
                 val builder = when (it.clazz) {
                     ConferenceModifyIQ::class -> Colibri2JSONDeserializer.deserializeConferenceModify(json)
                     ConferenceModifiedIQ::class -> {
-                        Colibri2JSONDeserializer.deserializeConferenceModified(json).also {
-                            it.ofType(IQ.Type.result)
+                        Colibri2JSONDeserializer.deserializeConferenceModified(json).also { b ->
+                            b.ofType(IQ.Type.result)
                         }
                     }
                     else -> throw IllegalStateException("Bad type in test")


### PR DESCRIPTION
Replace the `org.json.simple` dependency with Jackson (`jackson-databind`).

- Migrate `JSONSerializer`, `JSONDeserializer` (colibri), `Colibri2JSONSerializer`, `Colibri2JSONDeserializer` to use `ObjectNode`/`ArrayNode`
- Public API now uses `ObjectNode`/`ArrayNode` instead of `JSONObject`/`JSONArray`
- Update `jitsi-utils` to `1.0-SNAPSHOT`