### PR TITLE
Add exports/requests source-name lists and translator type to connect

### DIFF
--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/Connect.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/Connect.kt
@@ -65,6 +65,34 @@ class Connect(
     }
     fun removePing() = getPing()?.let { removeChildExtension(it) }
 
+    fun getExports(): List<String> =
+        getChildExtensionsOfType(Exports::class.java).firstOrNull()?.getNames() ?: emptyList()
+    fun addExport(name: String) {
+        val exports = getChildExtensionsOfType(Exports::class.java).firstOrNull()
+            ?: Exports().also { addChildExtension(it) }
+        exports.addExport(name)
+    }
+    fun setExports(names: List<String>) {
+        getChildExtensionsOfType(Exports::class.java).forEach { removeChildExtension(it) }
+        if (names.isNotEmpty()) {
+            addChildExtension(Exports(names))
+        }
+    }
+
+    fun getRequests(): List<String> =
+        getChildExtensionsOfType(Requests::class.java).firstOrNull()?.getNames() ?: emptyList()
+    fun addRequest(name: String) {
+        val requests = getChildExtensionsOfType(Requests::class.java).firstOrNull()
+            ?: Requests().also { addChildExtension(it) }
+        requests.addRequest(name)
+    }
+    fun setRequests(names: List<String>) {
+        getChildExtensionsOfType(Requests::class.java).forEach { removeChildExtension(it) }
+        if (names.isNotEmpty()) {
+            addChildExtension(Requests(names))
+        }
+    }
+
     class HttpHeader(val name: String, val value: String) : AbstractPacketExtension(NAMESPACE, ELEMENT) {
         init {
             setAttribute(NAME_ATTR_NAME, name)
@@ -91,13 +119,72 @@ class Connect(
         }
     }
 
+    /** A container for the source names this connection should export (send out). */
+    class Exports() : AbstractPacketExtension(NAMESPACE, ELEMENT) {
+        constructor(names: List<String>) : this() {
+            names.forEach { addChildExtension(Export(it)) }
+        }
+
+        fun getNames(): List<String> = getChildExtensionsOfType(Export::class.java).map { it.name }
+        fun addExport(name: String) = addChildExtension(Export(name))
+
+        companion object {
+            const val ELEMENT = "exports"
+        }
+    }
+
+    /** A single exported source, identified by its source name. */
+    class Export(name: String) : AbstractPacketExtension(NAMESPACE, ELEMENT) {
+        init {
+            setAttribute(NAME_ATTR_NAME, name)
+        }
+
+        val name: String
+            get() = getAttributeAsString(NAME_ATTR_NAME)
+
+        companion object {
+            const val ELEMENT = "export"
+            const val NAME_ATTR_NAME = "name"
+        }
+    }
+
+    /** A container for the source names this connection requests (wants to receive). */
+    class Requests() : AbstractPacketExtension(NAMESPACE, ELEMENT) {
+        constructor(names: List<String>) : this() {
+            names.forEach { addChildExtension(Request(it)) }
+        }
+
+        fun getNames(): List<String> = getChildExtensionsOfType(Request::class.java).map { it.name }
+        fun addRequest(name: String) = addChildExtension(Request(name))
+
+        companion object {
+            const val ELEMENT = "requests"
+        }
+    }
+
+    /** A single requested source, identified by its source name. */
+    class Request(name: String) : AbstractPacketExtension(NAMESPACE, ELEMENT) {
+        init {
+            setAttribute(NAME_ATTR_NAME, name)
+        }
+
+        val name: String
+            get() = getAttributeAsString(NAME_ATTR_NAME)
+
+        companion object {
+            const val ELEMENT = "request"
+            const val NAME_ATTR_NAME = "name"
+        }
+    }
+
     enum class Protocols(val value: String) {
         MEDIAJSON("mediajson")
     }
 
     enum class Types(val value: String) {
         RECORDER("recorder"),
-        TRANSCRIBER("transcriber")
+        TRANSCRIBER("transcriber"),
+        TRANSLATOR("translator")
     }
 
     companion object {
@@ -186,6 +273,16 @@ class ConnectProvider : DefaultPacketExtensionProvider<Connect>(Connect::class.j
                             }
                             connect.setPing(interval, timeout)
                         }
+                        Connect.Exports.ELEMENT -> {
+                            connect.setExports(
+                                parseSourceNames(parser, Connect.Exports.ELEMENT, Connect.Export.ELEMENT)
+                            )
+                        }
+                        Connect.Requests.ELEMENT -> {
+                            connect.setRequests(
+                                parseSourceNames(parser, Connect.Requests.ELEMENT, Connect.Request.ELEMENT)
+                            )
+                        }
                     }
                 }
                 XmlPullParser.Event.END_ELEMENT -> {
@@ -198,5 +295,35 @@ class ConnectProvider : DefaultPacketExtensionProvider<Connect>(Connect::class.j
         }
 
         return connect
+    }
+
+    /**
+     * Parses a container element (e.g. <exports>) holding a list of source-name items (e.g. <export name='...'/>),
+     * returning the list of source names. The parser is left positioned on the container's end element.
+     */
+    @Throws(XmlPullParserException::class, IOException::class, SmackParsingException::class)
+    private fun parseSourceNames(parser: XmlPullParser, containerElement: String, itemElement: String): List<String> {
+        val names = mutableListOf<String>()
+        var done = false
+        while (!done) {
+            when (parser.next()) {
+                XmlPullParser.Event.START_ELEMENT -> {
+                    if (parser.name == itemElement) {
+                        val name = parser.getAttributeValue("", Connect.Export.NAME_ATTR_NAME)
+                            ?: throw SmackParsingException.RequiredAttributeMissingException(
+                                "Missing 'name' attribute in $itemElement element"
+                            )
+                        names.add(name)
+                    }
+                }
+                XmlPullParser.Event.END_ELEMENT -> {
+                    if (parser.name == containerElement) {
+                        done = true
+                    }
+                }
+                else -> { /* ignore */ }
+            }
+        }
+        return names
     }
 }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONDeserializer.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONDeserializer.kt
@@ -396,6 +396,32 @@ object Colibri2JSONDeserializer {
                         }
                     }
 
+                    // Deserialize exports
+                    connect[Connect.Exports.ELEMENT]?.let { exports ->
+                        require(exports is ArrayNode) {
+                            "Expected array for ${Connect.Exports.ELEMENT}, got ${exports.nodeType}"
+                        }
+                        exports.forEach { export ->
+                            require(export.isTextual) {
+                                "Expected string for ${Connect.Export.ELEMENT}, got ${export.nodeType}"
+                            }
+                            connectObj.addExport(export.asText())
+                        }
+                    }
+
+                    // Deserialize requests
+                    connect[Connect.Requests.ELEMENT]?.let { requests ->
+                        require(requests is ArrayNode) {
+                            "Expected array for ${Connect.Requests.ELEMENT}, got ${requests.nodeType}"
+                        }
+                        requests.forEach { request ->
+                            require(request.isTextual) {
+                                "Expected string for ${Connect.Request.ELEMENT}, got ${request.nodeType}"
+                            }
+                            connectObj.addRequest(request.asText())
+                        }
+                    }
+
                     addConnect(connectObj)
                     added = true
                 }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializer.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializer.kt
@@ -258,6 +258,22 @@ object Colibri2JSONSerializer {
             pingObj.put(Connect.Ping.TIMEOUT_ATTR_NAME, ping.timeout)
             set<ObjectNode>("ping", pingObj)
         }
+
+        // Serialize exports
+        val exports = connect.getExports()
+        if (exports.isNotEmpty()) {
+            val exportsArray = JsonNodeFactory.instance.arrayNode()
+            exports.forEach { exportsArray.add(it) }
+            set<ArrayNode>(Connect.Exports.ELEMENT, exportsArray)
+        }
+
+        // Serialize requests
+        val requests = connect.getRequests()
+        if (requests.isNotEmpty()) {
+            val requestsArray = JsonNodeFactory.instance.arrayNode()
+            requests.forEach { requestsArray.add(it) }
+            set<ArrayNode>(Connect.Requests.ELEMENT, requestsArray)
+        }
     }
 
     private fun serializeConnects(connects: Connects) = JsonNodeFactory.instance.arrayNode().apply {

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/ConnectTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/ConnectTest.kt
@@ -363,5 +363,114 @@ class ConnectTest : ShouldSpec() {
                 connect.getPing() shouldBe null
             }
         }
+
+        context("Parsing exports and requests") {
+            context("With exports and requests") {
+                val connect = provider.parse(
+                    PacketParserUtils.getParserFor(
+                        """<connect url='$url' protocol='mediajson' type='translator'>
+                            <exports>
+                                <export name='523834112-a0'/>
+                                <export name='2394a3432-a0'/>
+                            </exports>
+                            <requests>
+                                <request name='523834112-a0.en'/>
+                                <request name='2394a3432-a0.hi'/>
+                            </requests>
+                        </connect>"""
+                    )
+                )
+                connect.type shouldBe Connect.Types.TRANSLATOR
+                connect.getExports() shouldBe listOf("523834112-a0", "2394a3432-a0")
+                connect.getRequests() shouldBe listOf("523834112-a0.en", "2394a3432-a0.hi")
+            }
+
+            context("With empty containers") {
+                val connect = provider.parse(
+                    PacketParserUtils.getParserFor(
+                        """<connect url='$url' protocol='mediajson' type='translator'>
+                            <exports/>
+                            <requests/>
+                        </connect>"""
+                    )
+                )
+                connect.getExports() shouldBe emptyList()
+                connect.getRequests() shouldBe emptyList()
+            }
+
+            context("Without exports or requests") {
+                val connect = provider.parse(
+                    PacketParserUtils.getParserFor("<connect url='$url' protocol='mediajson' type='translator'/>")
+                )
+                connect.getExports() shouldBe emptyList()
+                connect.getRequests() shouldBe emptyList()
+            }
+
+            context("Export missing name attribute") {
+                shouldThrow<SmackParsingException> {
+                    provider.parse(
+                        PacketParserUtils.getParserFor(
+                            """<connect url='$url' protocol='mediajson' type='translator'>
+                                <exports><export/></exports>
+                            </connect>"""
+                        )
+                    )
+                }
+            }
+
+            context("Request missing name attribute") {
+                shouldThrow<SmackParsingException> {
+                    provider.parse(
+                        PacketParserUtils.getParserFor(
+                            """<connect url='$url' protocol='mediajson' type='translator'>
+                                <requests><request/></requests>
+                            </connect>"""
+                        )
+                    )
+                }
+            }
+        }
+
+        context("Exports and requests manipulation") {
+            context("Setting exports and requests") {
+                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
+
+                connect.setExports(listOf("523834112-a0", "2394a3432-a0"))
+                connect.setRequests(listOf("523834112-a0.en"))
+
+                connect.getExports() shouldBe listOf("523834112-a0", "2394a3432-a0")
+                connect.getRequests() shouldBe listOf("523834112-a0.en")
+            }
+
+            context("Adding exports and requests") {
+                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
+
+                connect.addExport("523834112-a0")
+                connect.addExport("2394a3432-a0")
+                connect.addRequest("523834112-a0.en")
+
+                connect.getExports() shouldBe listOf("523834112-a0", "2394a3432-a0")
+                connect.getRequests() shouldBe listOf("523834112-a0.en")
+            }
+
+            context("Replacing exports") {
+                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
+
+                connect.setExports(listOf("523834112-a0"))
+                connect.setExports(listOf("2394a3432-a0"))
+
+                connect.getExports() shouldBe listOf("2394a3432-a0")
+            }
+
+            context("Round-trip through XML") {
+                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
+                connect.setExports(listOf("523834112-a0", "2394a3432-a0"))
+                connect.setRequests(listOf("523834112-a0.en", "2394a3432-a0.hi"))
+
+                val parsed = provider.parse(PacketParserUtils.getParserFor(connect.toXML().toString()))
+                parsed.getExports() shouldBe listOf("523834112-a0", "2394a3432-a0")
+                parsed.getRequests() shouldBe listOf("523834112-a0.en", "2394a3432-a0.hi")
+            }
+        }
     }
 }

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializerTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializerTest.kt
@@ -673,5 +673,48 @@ private val expectedMappings = listOf(
 }
         """,
         clazz = ConferenceModifyIQ::class
+    ),
+    Mapping(
+        name = "Connect with exports and requests",
+        xml = """
+<iq xmlns="jabber:client" id="id" type="get">
+  <conference-modify xmlns="jitsi:colibri2" meeting-id="test-meeting-id" create="true">
+    <connects>
+      <connect url='wss://example.com/webhook' protocol='mediajson' type='translator'>
+        <exports>
+          <export name='523834112-a0'/>
+          <export name='2394a3432-a0'/>
+        </exports>
+        <requests>
+          <request name='523834112-a0.en'/>
+          <request name='2394a3432-a0.hi'/>
+        </requests>
+      </connect>
+    </connects>
+  </conference-modify>
+</iq>
+        """,
+        json = """
+{
+  "meeting-id": "test-meeting-id",
+  "create": true,
+  "connects": [
+    {
+      "url": "wss://example.com/webhook",
+      "protocol": "mediajson",
+      "type": "translator",
+      "exports": [
+        "523834112-a0",
+        "2394a3432-a0"
+      ],
+      "requests": [
+        "523834112-a0.en",
+        "2394a3432-a0.hi"
+      ]
+    }
+  ]
+}
+        """,
+        clazz = ConferenceModifyIQ::class
     )
 )


### PR DESCRIPTION
Extend the colibri2 `<connect>` element with two optional child containers and a new connection type.

### Changes
- **`<exports>` / `<requests>` containers** on `<connect>`, each holding `<export>` / `<request>` items that reference a source by its `name` attribute (the source-name idiom used by `Capability` / `SourcePacketExtension`):
  ```xml
  <connect url='...' protocol='mediajson' type='translator'>
    <exports><export name='523834112-a0'/><export name='2394a3432-a0'/></exports>
    <requests><request name='523834112-a0.en'/><request name='2394a3432-a0.hi'/></requests>
  </connect>
  ```
- **New `translator` connect type** alongside `recorder` / `transcriber`.
- Wired through the XML provider and the Jackson-based JSON serializer/deserializer (exports/requests serialize as JSON string arrays).
- XML and bidirectional JSON round-trip test coverage.

### Note
This is based on the Jackson migration in #139, so it targets that branch rather than `master`. It should be merged with/after #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)