### PR TITLE
feat: Add id, create and expire to colibri2 connect

### DIFF
--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/Connect.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/Connect.kt
@@ -25,13 +25,23 @@ import java.io.IOException
 import java.net.URI
 
 class Connect(
+    /**
+     * The identity of this connection within its conference. The bridge keys connections by [id], so multiple
+     * connects with the same [url] are allowed as long as their [id]s differ. Required.
+     */
+    val id: String,
     val url: URI,
     val protocol: Protocols,
     val type: Types,
     audio: Boolean = false,
-    video: Boolean = false
+    video: Boolean = false,
+    /** Marks this as a new connection. The bridge rejects a create for an already-existing [id]. */
+    create: Boolean = false,
+    /** Marks this connection for removal. */
+    expire: Boolean = false
 ) : AbstractPacketExtension(NAMESPACE, ELEMENT) {
     init {
+        setAttribute(ID_ATTR_NAME, id)
         setAttribute(URL_ATTR_NAME, url)
         setAttribute(PROTOCOL_ATTR_NAME, protocol.toString().lowercase())
         setAttribute(TYPE_ATTR_NAME, type.toString().lowercase())
@@ -41,12 +51,26 @@ class Connect(
         if (video) {
             setAttribute(VIDEO_ATTR_NAME, true)
         }
+        if (create) {
+            setAttribute(CREATE_ATTR_NAME, true)
+        }
+        if (expire) {
+            setAttribute(EXPIRE_ATTR_NAME, true)
+        }
     }
 
     val audio: Boolean
         get() = getAttributeAsString(AUDIO_ATTR_NAME)?.toBoolean() ?: false
     val video: Boolean
         get() = getAttributeAsString(VIDEO_ATTR_NAME)?.toBoolean() ?: false
+
+    /** Whether this connect is marked as a new connection. */
+    val create: Boolean
+        get() = getAttributeAsString(CREATE_ATTR_NAME)?.toBoolean() ?: false
+
+    /** Whether this connect is marked for removal. */
+    val expire: Boolean
+        get() = getAttributeAsString(EXPIRE_ATTR_NAME)?.toBoolean() ?: false
 
     fun getHttpHeaders(): List<HttpHeader> = getChildExtensionsOfType(HttpHeader::class.java)
     fun addHttpHeader(name: String, value: String) = addChildExtension(HttpHeader(name, value))
@@ -186,17 +210,22 @@ class Connect(
     companion object {
         const val ELEMENT = "connect"
         const val NAMESPACE = ConferenceModifyIQ.NAMESPACE
+        const val ID_ATTR_NAME = "id"
         const val URL_ATTR_NAME = "url"
         const val PROTOCOL_ATTR_NAME = "protocol"
         const val TYPE_ATTR_NAME = "type"
         const val AUDIO_ATTR_NAME = "audio"
         const val VIDEO_ATTR_NAME = "video"
+        const val CREATE_ATTR_NAME = "create"
+        const val EXPIRE_ATTR_NAME = "expire"
     }
 }
 
 class ConnectProvider : DefaultPacketExtensionProvider<Connect>(Connect::class.java) {
     @Throws(XmlPullParserException::class, IOException::class, SmackParsingException::class)
     override fun parse(parser: XmlPullParser, depth: Int, xml: XmlEnvironment?): Connect {
+        val id = parser.getAttributeValue("", Connect.ID_ATTR_NAME)
+            ?: throw SmackParsingException.RequiredAttributeMissingException("Missing 'id' attribute")
         val url = parser.getAttributeValue("", Connect.URL_ATTR_NAME)
             ?: throw SmackParsingException.RequiredAttributeMissingException("Missing 'url' attribute")
         val uri = try {
@@ -224,7 +253,19 @@ class ConnectProvider : DefaultPacketExtensionProvider<Connect>(Connect::class.j
             throw SmackParsingException("Invalid 'type': $typeStr")
         }
 
-        val connect = Connect(url = uri, protocol = protocol, type = type, audio = audio, video = video)
+        val create = parser.getAttributeValue("", Connect.CREATE_ATTR_NAME)?.toBoolean() ?: false
+        val expire = parser.getAttributeValue("", Connect.EXPIRE_ATTR_NAME)?.toBoolean() ?: false
+
+        val connect = Connect(
+            id = id,
+            url = uri,
+            protocol = protocol,
+            type = type,
+            audio = audio,
+            video = video,
+            create = create,
+            expire = expire
+        )
 
         // Parse child elements manually
         var done = false

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONDeserializer.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONDeserializer.kt
@@ -357,7 +357,8 @@ object Colibri2JSONDeserializer {
                 it.forEach { connect ->
                     require(connect is ObjectNode) { "Expected object for connect element, got ${connect.nodeType}" }
                     val connectObj = Connect(
-                        URI(connect[Connect.URL_ATTR_NAME]!!.asText()),
+                        id = connect[Connect.ID_ATTR_NAME]!!.asText(),
+                        url = URI(connect[Connect.URL_ATTR_NAME]!!.asText()),
                         protocol = Connect.Protocols.valueOf(
                             connect[Connect.PROTOCOL_ATTR_NAME]!!.asText().uppercase()
                         ),
@@ -365,7 +366,9 @@ object Colibri2JSONDeserializer {
                             connect[Connect.TYPE_ATTR_NAME]!!.asText().uppercase()
                         ),
                         audio = connect[Connect.AUDIO_ATTR_NAME]?.asBoolean() ?: false,
-                        video = connect[Connect.VIDEO_ATTR_NAME]?.asBoolean() ?: false
+                        video = connect[Connect.VIDEO_ATTR_NAME]?.asBoolean() ?: false,
+                        create = connect[Connect.CREATE_ATTR_NAME]?.asBoolean() ?: false,
+                        expire = connect[Connect.EXPIRE_ATTR_NAME]?.asBoolean() ?: false
                     )
 
                     // Deserialize HTTP headers

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializer.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializer.kt
@@ -236,11 +236,14 @@ object Colibri2JSONSerializer {
     }
 
     private fun serializeConnect(connect: Connect) = JsonNodeFactory.instance.objectNode().apply {
+        put(Connect.ID_ATTR_NAME, connect.id)
         put(Connect.URL_ATTR_NAME, connect.url.toString())
         put(Connect.PROTOCOL_ATTR_NAME, connect.protocol.toString().lowercase())
         put(Connect.TYPE_ATTR_NAME, connect.type.toString().lowercase())
         if (connect.audio) put(Connect.AUDIO_ATTR_NAME, true)
         if (connect.video) put(Connect.VIDEO_ATTR_NAME, true)
+        if (connect.create) put(Connect.CREATE_ATTR_NAME, true)
+        if (connect.expire) put(Connect.EXPIRE_ATTR_NAME, true)
 
         // Serialize HTTP headers
         val headers = connect.getHttpHeaders()

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/ConnectTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/ConnectTest.kt
@@ -31,18 +31,43 @@ class ConnectTest : ShouldSpec() {
         context("Parsing a valid extension") {
             context("Without audio/video") {
                 val connect = provider.parse(
-                    PacketParserUtils.getParserFor("<connect url='$url' protocol='mediajson' type='recorder'/>")
+                    PacketParserUtils.getParserFor(
+                        "<connect id='conn' url='$url' protocol='mediajson' type='recorder'/>"
+                    )
                 )
+                connect.id shouldBe "conn"
                 connect.url shouldBe URI(url)
                 connect.protocol shouldBe Connect.Protocols.MEDIAJSON
                 connect.type shouldBe Connect.Types.RECORDER
                 connect.audio shouldBe false
                 connect.video shouldBe false
+                connect.create shouldBe false
+                connect.expire shouldBe false
+            }
+            context("With create and expire") {
+                provider.parse(
+                    PacketParserUtils.getParserFor(
+                        "<connect id='c1' url='$url' protocol='mediajson' type='translator' create='true'/>"
+                    )
+                ).let {
+                    it.id shouldBe "c1"
+                    it.create shouldBe true
+                    it.expire shouldBe false
+                }
+                provider.parse(
+                    PacketParserUtils.getParserFor(
+                        "<connect id='c2' url='$url' protocol='mediajson' type='translator' expire='true'/>"
+                    )
+                ).let {
+                    it.id shouldBe "c2"
+                    it.create shouldBe false
+                    it.expire shouldBe true
+                }
             }
             context("With audio") {
                 val connect = provider.parse(
                     PacketParserUtils.getParserFor(
-                        "<connect url='$url' protocol='mediajson' type='recorder' audio='true'/>"
+                        "<connect id='conn' url='$url' protocol='mediajson' type='recorder' audio='true'/>"
                     )
                 )
                 connect.url shouldBe URI(url)
@@ -54,7 +79,7 @@ class ConnectTest : ShouldSpec() {
             context("With video") {
                 val connect = provider.parse(
                     PacketParserUtils.getParserFor(
-                        "<connect url='$url' protocol='mediajson' type='transcriber' audio='false' video='true'/>"
+                        "<connect id='conn' url='$url' protocol='mediajson' type='transcriber' video='true'/>"
                     )
                 )
                 connect.url shouldBe URI(url)
@@ -64,38 +89,53 @@ class ConnectTest : ShouldSpec() {
                 connect.video shouldBe true
             }
         }
+        context("Parsing with missing id") {
+            shouldThrow<SmackParsingException> {
+                provider.parse(
+                    PacketParserUtils.getParserFor("<connect url='$url' protocol='mediajson' type='recorder'/>")
+                )
+            }
+        }
         context("Parsing with missing url") {
             shouldThrow<SmackParsingException> {
                 provider.parse(
-                    PacketParserUtils.getParserFor("<connect protocol='mediajson' type='recorder '></connect>")
+                    PacketParserUtils.getParserFor(
+                        "<connect id='conn' protocol='mediajson' type='recorder '></connect>"
+                    )
                 )
             }
         }
         context("Parsing with invalid url") {
             shouldThrow<SmackParsingException> {
                 provider.parse(
-                    PacketParserUtils.getParserFor("<connect url='in val id' protocol='mediajson' type='recorder'/>")
+                    PacketParserUtils.getParserFor(
+                        "<connect id='conn' url='in val id' protocol='mediajson' type='recorder'/>"
+                    )
                 )
             }
         }
         context("Parsing with missing protocol") {
             shouldThrow<SmackParsingException> {
-                provider.parse(PacketParserUtils.getParserFor("<connect url='$url' type='recorder'/>"))
+                provider.parse(PacketParserUtils.getParserFor("<connect id='conn' url='$url' type='recorder'/>"))
             }
         }
         context("Parsing with invalid protocol") {
             shouldThrow<SmackParsingException> {
-                provider.parse(PacketParserUtils.getParserFor("<connect url='$url' protocol='abc' type='recorder'/>"))
+                provider.parse(
+                    PacketParserUtils.getParserFor("<connect id='conn' url='$url' protocol='abc' type='recorder'/>")
+                )
             }
         }
         context("Parsing with missing type") {
             shouldThrow<SmackParsingException> {
-                provider.parse(PacketParserUtils.getParserFor("<connect url='$url' protocol='mediajson'/>"))
+                provider.parse(PacketParserUtils.getParserFor("<connect id='conn' url='$url' protocol='mediajson'/>"))
             }
         }
         context("Parsing with invalid type") {
             shouldThrow<SmackParsingException> {
-                provider.parse(PacketParserUtils.getParserFor("<connect url='$url' protocol='mediajson' type='inv'/>"))
+                provider.parse(
+                    PacketParserUtils.getParserFor("<connect id='conn' url='$url' protocol='mediajson' type='inv'/>")
+                )
             }
         }
 
@@ -103,7 +143,7 @@ class ConnectTest : ShouldSpec() {
             context("Single HTTP header") {
                 val connect = provider.parse(
                     PacketParserUtils.getParserFor(
-                        """<connect url='$url' protocol='mediajson' type='recorder'>
+                        """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                             <http-header name='Authorization' value='Bearer token123'/>
                         </connect>"""
                     )
@@ -117,7 +157,7 @@ class ConnectTest : ShouldSpec() {
             context("Multiple HTTP headers") {
                 val connect = provider.parse(
                     PacketParserUtils.getParserFor(
-                        """<connect url='$url' protocol='mediajson' type='recorder'>
+                        """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                             <http-header name='Authorization' value='Bearer token123'/>
                             <http-header name='Content-Type' value='application/json'/>
                             <http-header name='User-Agent' value='blabla'/>
@@ -134,7 +174,9 @@ class ConnectTest : ShouldSpec() {
 
             context("No HTTP headers") {
                 val connect = provider.parse(
-                    PacketParserUtils.getParserFor("<connect url='$url' protocol='mediajson' type='recorder'/>")
+                    PacketParserUtils.getParserFor(
+                        "<connect id='conn' url='$url' protocol='mediajson' type='recorder'/>"
+                    )
                 )
                 connect.getHttpHeaders().size shouldBe 0
             }
@@ -144,7 +186,7 @@ class ConnectTest : ShouldSpec() {
                     shouldThrow<SmackParsingException> {
                         provider.parse(
                             PacketParserUtils.getParserFor(
-                                """<connect url='$url' protocol='mediajson' type='recorder'>
+                                """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                                     <http-header value='Bearer token123'/>
                                 </connect>"""
                             )
@@ -156,7 +198,7 @@ class ConnectTest : ShouldSpec() {
                     shouldThrow<SmackParsingException> {
                         provider.parse(
                             PacketParserUtils.getParserFor(
-                                """<connect url='$url' protocol='mediajson' type='recorder'>
+                                """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                                     <http-header name='Authorization'/>
                                 </connect>"""
                             )
@@ -168,7 +210,7 @@ class ConnectTest : ShouldSpec() {
                     shouldThrow<SmackParsingException> {
                         provider.parse(
                             PacketParserUtils.getParserFor(
-                                """<connect url='$url' protocol='mediajson' type='recorder'>
+                                """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                                     <http-header/>
                                 </connect>"""
                             )
@@ -180,7 +222,7 @@ class ConnectTest : ShouldSpec() {
 
         context("HTTP header manipulation") {
             context("Adding headers") {
-                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
+                val connect = Connect("conn", URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
 
                 connect.addHttpHeader("Authorization", "Bearer token123")
                 connect.addHttpHeader("Content-Type", "application/json")
@@ -192,7 +234,7 @@ class ConnectTest : ShouldSpec() {
             }
 
             context("Adding header object") {
-                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
+                val connect = Connect("conn", URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
                 val header = Connect.HttpHeader("Custom-Header", "custom-value")
 
                 connect.addHttpHeader(header)
@@ -203,7 +245,7 @@ class ConnectTest : ShouldSpec() {
             }
 
             context("Removing headers") {
-                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
+                val connect = Connect("conn", URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
 
                 connect.addHttpHeader("Authorization", "Bearer token123")
                 connect.addHttpHeader("Content-Type", "application/json")
@@ -223,7 +265,7 @@ class ConnectTest : ShouldSpec() {
             context("With ping element") {
                 val connect = provider.parse(
                     PacketParserUtils.getParserFor(
-                        """<connect url='$url' protocol='mediajson' type='recorder'>
+                        """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                             <ping interval='1234' timeout='5678'/>
                         </connect>"""
                     )
@@ -235,7 +277,9 @@ class ConnectTest : ShouldSpec() {
 
             context("Without ping element") {
                 val connect = provider.parse(
-                    PacketParserUtils.getParserFor("<connect url='$url' protocol='mediajson' type='recorder'/>")
+                    PacketParserUtils.getParserFor(
+                        "<connect id='conn' url='$url' protocol='mediajson' type='recorder'/>"
+                    )
                 )
                 connect.getPing() shouldBe null
             }
@@ -243,7 +287,7 @@ class ConnectTest : ShouldSpec() {
             context("With ping and HTTP headers") {
                 val connect = provider.parse(
                     PacketParserUtils.getParserFor(
-                        """<connect url='$url' protocol='mediajson' type='recorder'>
+                        """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                             <http-header name='Authorization' value='Bearer token123'/>
                             <ping interval='1000' timeout='2000'/>
                         </connect>"""
@@ -262,7 +306,7 @@ class ConnectTest : ShouldSpec() {
                     shouldThrow<SmackParsingException> {
                         provider.parse(
                             PacketParserUtils.getParserFor(
-                                """<connect url='$url' protocol='mediajson' type='recorder'>
+                                """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                                     <ping timeout='5678'/>
                                 </connect>"""
                             )
@@ -274,7 +318,7 @@ class ConnectTest : ShouldSpec() {
                     shouldThrow<SmackParsingException> {
                         provider.parse(
                             PacketParserUtils.getParserFor(
-                                """<connect url='$url' protocol='mediajson' type='recorder'>
+                                """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                                     <ping interval='1234'/>
                                 </connect>"""
                             )
@@ -286,7 +330,7 @@ class ConnectTest : ShouldSpec() {
                     shouldThrow<SmackParsingException> {
                         provider.parse(
                             PacketParserUtils.getParserFor(
-                                """<connect url='$url' protocol='mediajson' type='recorder'>
+                                """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                                     <ping/>
                                 </connect>"""
                             )
@@ -298,7 +342,7 @@ class ConnectTest : ShouldSpec() {
                     shouldThrow<SmackParsingException> {
                         provider.parse(
                             PacketParserUtils.getParserFor(
-                                """<connect url='$url' protocol='mediajson' type='recorder'>
+                                """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                                     <ping interval='not-a-number' timeout='5678'/>
                                 </connect>"""
                             )
@@ -310,7 +354,7 @@ class ConnectTest : ShouldSpec() {
                     shouldThrow<SmackParsingException> {
                         provider.parse(
                             PacketParserUtils.getParserFor(
-                                """<connect url='$url' protocol='mediajson' type='recorder'>
+                                """<connect id='conn' url='$url' protocol='mediajson' type='recorder'>
                                     <ping interval='1234' timeout='not-a-number'/>
                                 </connect>"""
                             )
@@ -322,7 +366,7 @@ class ConnectTest : ShouldSpec() {
 
         context("Ping manipulation") {
             context("Setting ping") {
-                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
+                val connect = Connect("conn", URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
 
                 connect.setPing(1234, 5678)
 
@@ -332,7 +376,7 @@ class ConnectTest : ShouldSpec() {
             }
 
             context("Setting ping object") {
-                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
+                val connect = Connect("conn", URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
                 val pingObj = Connect.Ping(3000, 4000)
 
                 connect.setPing(pingObj)
@@ -343,7 +387,7 @@ class ConnectTest : ShouldSpec() {
             }
 
             context("Replacing ping") {
-                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
+                val connect = Connect("conn", URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
 
                 connect.setPing(1000, 2000)
                 connect.setPing(3000, 4000)
@@ -354,7 +398,7 @@ class ConnectTest : ShouldSpec() {
             }
 
             context("Removing ping") {
-                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
+                val connect = Connect("conn", URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER)
 
                 connect.setPing(1234, 5678)
                 connect.getPing()!!
@@ -368,7 +412,7 @@ class ConnectTest : ShouldSpec() {
             context("With exports and requests") {
                 val connect = provider.parse(
                     PacketParserUtils.getParserFor(
-                        """<connect url='$url' protocol='mediajson' type='translator'>
+                        """<connect id='conn' url='$url' protocol='mediajson' type='translator'>
                             <exports>
                                 <export name='523834112-a0'/>
                                 <export name='2394a3432-a0'/>
@@ -388,7 +432,7 @@ class ConnectTest : ShouldSpec() {
             context("With empty containers") {
                 val connect = provider.parse(
                     PacketParserUtils.getParserFor(
-                        """<connect url='$url' protocol='mediajson' type='translator'>
+                        """<connect id='conn' url='$url' protocol='mediajson' type='translator'>
                             <exports/>
                             <requests/>
                         </connect>"""
@@ -400,7 +444,9 @@ class ConnectTest : ShouldSpec() {
 
             context("Without exports or requests") {
                 val connect = provider.parse(
-                    PacketParserUtils.getParserFor("<connect url='$url' protocol='mediajson' type='translator'/>")
+                    PacketParserUtils.getParserFor(
+                        "<connect id='conn' url='$url' protocol='mediajson' type='translator'/>"
+                    )
                 )
                 connect.getExports() shouldBe emptyList()
                 connect.getRequests() shouldBe emptyList()
@@ -410,7 +456,7 @@ class ConnectTest : ShouldSpec() {
                 shouldThrow<SmackParsingException> {
                     provider.parse(
                         PacketParserUtils.getParserFor(
-                            """<connect url='$url' protocol='mediajson' type='translator'>
+                            """<connect id='conn' url='$url' protocol='mediajson' type='translator'>
                                 <exports><export/></exports>
                             </connect>"""
                         )
@@ -422,7 +468,7 @@ class ConnectTest : ShouldSpec() {
                 shouldThrow<SmackParsingException> {
                     provider.parse(
                         PacketParserUtils.getParserFor(
-                            """<connect url='$url' protocol='mediajson' type='translator'>
+                            """<connect id='conn' url='$url' protocol='mediajson' type='translator'>
                                 <requests><request/></requests>
                             </connect>"""
                         )
@@ -433,7 +479,7 @@ class ConnectTest : ShouldSpec() {
 
         context("Exports and requests manipulation") {
             context("Setting exports and requests") {
-                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
+                val connect = Connect("conn", URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
 
                 connect.setExports(listOf("523834112-a0", "2394a3432-a0"))
                 connect.setRequests(listOf("523834112-a0.en"))
@@ -443,7 +489,7 @@ class ConnectTest : ShouldSpec() {
             }
 
             context("Adding exports and requests") {
-                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
+                val connect = Connect("conn", URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
 
                 connect.addExport("523834112-a0")
                 connect.addExport("2394a3432-a0")
@@ -454,7 +500,7 @@ class ConnectTest : ShouldSpec() {
             }
 
             context("Replacing exports") {
-                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
+                val connect = Connect("conn", URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
 
                 connect.setExports(listOf("523834112-a0"))
                 connect.setExports(listOf("2394a3432-a0"))
@@ -463,13 +509,43 @@ class ConnectTest : ShouldSpec() {
             }
 
             context("Round-trip through XML") {
-                val connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
+                val connect = Connect("conn", URI(url), Connect.Protocols.MEDIAJSON, Connect.Types.TRANSLATOR)
                 connect.setExports(listOf("523834112-a0", "2394a3432-a0"))
                 connect.setRequests(listOf("523834112-a0.en", "2394a3432-a0.hi"))
 
                 val parsed = provider.parse(PacketParserUtils.getParserFor(connect.toXML().toString()))
+                parsed.id shouldBe "conn"
                 parsed.getExports() shouldBe listOf("523834112-a0", "2394a3432-a0")
                 parsed.getRequests() shouldBe listOf("523834112-a0.en", "2394a3432-a0.hi")
+            }
+        }
+
+        context("id/create/expire round-trip through XML") {
+            context("create") {
+                val connect = Connect(
+                    id = "c-create",
+                    url = URI(url),
+                    protocol = Connect.Protocols.MEDIAJSON,
+                    type = Connect.Types.TRANSLATOR,
+                    create = true
+                )
+                val parsed = provider.parse(PacketParserUtils.getParserFor(connect.toXML().toString()))
+                parsed.id shouldBe "c-create"
+                parsed.create shouldBe true
+                parsed.expire shouldBe false
+            }
+            context("expire") {
+                val connect = Connect(
+                    id = "c-expire",
+                    url = URI(url),
+                    protocol = Connect.Protocols.MEDIAJSON,
+                    type = Connect.Types.TRANSLATOR,
+                    expire = true
+                )
+                val parsed = provider.parse(PacketParserUtils.getParserFor(connect.toXML().toString()))
+                parsed.id shouldBe "c-expire"
+                parsed.create shouldBe false
+                parsed.expire shouldBe true
             }
         }
     }

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializerTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializerTest.kt
@@ -192,8 +192,8 @@ private val expectedMappings = listOf(
       <capability name="source-names"/>
     </endpoint>
     <connects>
-      <connect url='wss://example.com/audio' protocol='mediajson' type='transcriber' audio='true'/>
-      <connect url='wss://example.com/video' protocol='mediajson' type='recorder' video='true'/>
+      <connect id='c-audio' url='wss://example.com/audio' protocol='mediajson' type='transcriber' audio='true'/>
+      <connect id='c-video' url='wss://example.com/video' protocol='mediajson' type='recorder' video='true'/>
     </connects>
   </conference-modify>
 </iq>
@@ -283,8 +283,8 @@ private val expectedMappings = listOf(
     }
   ],
   "connects": [
-    { "url": "wss://example.com/audio", "protocol": "mediajson", "type": "transcriber", "audio": true },
-    { "url": "wss://example.com/video", "protocol": "mediajson", "type": "recorder", "video": true }
+    { "id": "c-audio", "url": "wss://example.com/audio", "protocol": "mediajson", "type": "transcriber", "audio": true },
+    { "id": "c-video", "url": "wss://example.com/video", "protocol": "mediajson", "type": "recorder", "video": true }
   ]
 }
         """,
@@ -576,7 +576,7 @@ private val expectedMappings = listOf(
 <iq xmlns="jabber:client" id="id" type="get">
   <conference-modify xmlns="jitsi:colibri2" meeting-id="test-meeting-id" create="true">
     <connects>
-      <connect url='wss://example.com/webhook' protocol='mediajson' type='recorder' audio='true'>
+      <connect id='c-webhook' url='wss://example.com/webhook' protocol='mediajson' type='recorder' audio='true'>
         <http-header name='Authorization' value='Bearer token123'/>
       </connect>
     </connects>
@@ -589,6 +589,7 @@ private val expectedMappings = listOf(
   "create": true,
   "connects": [
     {
+      "id": "c-webhook",
       "url": "wss://example.com/webhook",
       "protocol": "mediajson",
       "type": "recorder",
@@ -608,7 +609,7 @@ private val expectedMappings = listOf(
 <iq xmlns="jabber:client" id="id" type="get">
   <conference-modify xmlns="jitsi:colibri2" meeting-id="test-meeting-id" create="true">
     <connects>
-      <connect url='wss://example.com/webhook' protocol='mediajson' type='recorder' video='true'>
+      <connect id='c-webhook' url='wss://example.com/webhook' protocol='mediajson' type='recorder' video='true'>
         <ping interval='1234' timeout='5678'/>
       </connect>
     </connects>
@@ -621,6 +622,7 @@ private val expectedMappings = listOf(
   "create": true,
   "connects": [
     {
+      "id": "c-webhook",
       "url": "wss://example.com/webhook",
       "protocol": "mediajson",
       "type": "recorder",
@@ -641,7 +643,7 @@ private val expectedMappings = listOf(
 <iq xmlns="jabber:client" id="id" type="get">
   <conference-modify xmlns="jitsi:colibri2" meeting-id="test-meeting-id" create="true">
     <connects>
-      <connect url='wss://example.com/webhook' protocol='mediajson' type='transcriber' audio='true' video='true'>
+      <connect id='c-webhook' url='wss://example.com/webhook' protocol='mediajson' type='transcriber' audio='true' video='true'>
         <http-header name='Authorization' value='Bearer token123'/>
         <http-header name='Content-Type' value='application/json'/>
         <ping interval='1000' timeout='2000'/>
@@ -656,6 +658,7 @@ private val expectedMappings = listOf(
   "create": true,
   "connects": [
     {
+      "id": "c-webhook",
       "url": "wss://example.com/webhook",
       "protocol": "mediajson",
       "type": "transcriber",
@@ -681,7 +684,7 @@ private val expectedMappings = listOf(
 <iq xmlns="jabber:client" id="id" type="get">
   <conference-modify xmlns="jitsi:colibri2" meeting-id="test-meeting-id" create="true">
     <connects>
-      <connect url='wss://example.com/webhook' protocol='mediajson' type='translator'>
+      <connect id='c-webhook' url='wss://example.com/webhook' protocol='mediajson' type='translator'>
         <exports>
           <export name='523834112-a0'/>
           <export name='2394a3432-a0'/>
@@ -701,6 +704,7 @@ private val expectedMappings = listOf(
   "create": true,
   "connects": [
     {
+      "id": "c-webhook",
       "url": "wss://example.com/webhook",
       "protocol": "mediajson",
       "type": "translator",

--- a/src/test/kotlin/org/jitsi/xmpp/util/RedactColibriTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/util/RedactColibriTest.kt
@@ -226,7 +226,7 @@ class RedactColibriTest : ShouldSpec() {
 <iq xmlns="jabber:client" to="jvb@auth.example.com/abc" from="jvbbrewery@muc.example.com/focus" id="id1" type="get">
   <conference-modify xmlns="jitsi:colibri2" meeting-id="meeting1">
     <connects>
-      <connect url="wss://example.com/transcribe" protocol="mediajson" type="transcriber" audio="true">
+      <connect id="c1" url="wss://example.com/transcribe" protocol="mediajson" type="transcriber" audio="true">
         <http-header name="CF-Access-Client-Id" value="cbe9a437e2708707613764d16541fc95.access"/>
         <http-header name="CF-Access-Client-Secret" value="c76b8d1e20ccfd6b4059fc2837737514a9c91845eb7349d5e66a8127b03dd852"/>
         <http-header name="X-Custom-Api-Key" value="sk-proj-supersecret"/>
@@ -241,7 +241,7 @@ class RedactColibriTest : ShouldSpec() {
 <iq xmlns="jabber:client" to="jvb@auth.example.com/abc" from="jvbbrewery@muc.example.com/focus" id="id1" type="get">
   <conference-modify xmlns="jitsi:colibri2" meeting-id="meeting1">
     <connects>
-      <connect url="wss://example.com/transcribe" protocol="mediajson" type="transcriber" audio="true">
+      <connect id="c1" url="wss://example.com/transcribe" protocol="mediajson" type="transcriber" audio="true">
         <http-header name="CF-Access-Client-Id" value="[redacted]"/>
         <http-header name="CF-Access-Client-Secret" value="[redacted]"/>
         <http-header name="X-Custom-Api-Key" value="[redacted]"/>


### PR DESCRIPTION
Adds three attributes to the colibri2 `<connect>` element:

- **id** — lets multiple connects share a URL while being addressed individually.
- **create** / **expire** — mark a connect as a delta against the previously signaled set, so connects can be added, updated and removed individually instead of always re-sending the full authoritative list.

Parsing/serialization updated in the provider and the JSON (de)serializers; tests cover the new attributes including the now-required id.

Consumed by:
- jitsi/jitsi-videobridge#connect-id-delta (bridge-side delta handling)
- jicofo `translation` branch (signals connects as deltas)