### PR TITLE
Add rtp-mid-demux Colibri2 endpoint capability

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/colibri2/Capability.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri2/Capability.java
@@ -46,6 +46,12 @@ public class Capability extends AbstractPacketExtension
     public static final String CAP_PRIVATE_ADDRESS_CONNECTIVITY = "private-address-connectivity";
 
     /**
+     * The endpoint can demux forwarded media by the RTP sdes:mid header extension, allowing the bridge to stamp a mid
+     * on rewritten packets. Only meaningful together with {@link #CAP_SSRC_REWRITING_SUPPORT}.
+     */
+    public static final String CAP_RTP_MID_DEMUX_SUPPORT = "rtp-mid-demux";
+
+    /**
      * Creates an {@link Capability} instance.
      */
     public Capability()

--- a/src/test/java/org/jitsi/xmpp/extensions/colibri2/CapabilityTest.java
+++ b/src/test/java/org/jitsi/xmpp/extensions/colibri2/CapabilityTest.java
@@ -30,4 +30,21 @@ public class CapabilityTest
                 checkForIdentical().build();
         assertFalse(diff1.hasDifferences(), diff1.toString());
     }
+
+    @Test
+    public void rtpMidDemuxCapabilityTest()
+            throws Exception
+    {
+        assertEquals("rtp-mid-demux", Capability.CAP_RTP_MID_DEMUX_SUPPORT);
+
+        Capability cap = new Capability.Provider().parse(PacketParserUtils.getParserFor(
+                "<capability name='" + Capability.CAP_RTP_MID_DEMUX_SUPPORT + "'/>"));
+        assertEquals(Capability.CAP_RTP_MID_DEMUX_SUPPORT, cap.getName());
+
+        Diff diff = DiffBuilder.compare(
+            "<capability xmlns='jitsi:colibri2' name='" + Capability.CAP_RTP_MID_DEMUX_SUPPORT + "'/>").
+                withTest(new Capability(Capability.CAP_RTP_MID_DEMUX_SUPPORT).toXML().toString()).
+                checkForIdentical().build();
+        assertFalse(diff.hasDifferences(), diff.toString());
+    }
 }


### PR DESCRIPTION
## Summary

Adds a new Colibri2 endpoint capability constant, `CAP_RTP_MID_DEMUX_SUPPORT` (`"rtp-mid-demux"`), indicating that an endpoint can demux forwarded media by the RTP `sdes:mid` header extension. Only meaningful together with `ssrc-rewriting`.

This is the shared definition for the cross-repo **bridge-stamped mid** change — the durable fix for the Chrome/WebRTC silent audio-demux wedge under SSRC rewriting. Companion branches named `mid-demux-stamping` exist in **jitsi-videobridge**, **jicofo**, and **lib-jitsi-meet**; the Jitsi PR tester builds same-named branches together.

## Tests

Added a round-trip `CapabilityTest` case for the new constant. `mvn test` + `checkstyle:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
