### PR TITLE
feat: add diarize attribute to Colibri2Endpoint

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/colibri2/Colibri2Endpoint.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri2/Colibri2Endpoint.java
@@ -53,6 +53,11 @@ public class Colibri2Endpoint
     public static final String MUC_ROLE_ATTR_NAME = "muc-role";
 
     /**
+     * The name of the "diarize" attribute.
+     */
+    public static final String DIARIZE_ATTR_NAME = "diarize";
+
+    /**
      * Construct Colibri2Endpoint.  Needs to be public for DefaultPacketExtensionProvider to work.
      */
     public Colibri2Endpoint()
@@ -75,6 +80,11 @@ public class Colibri2Endpoint
         if (b.mucRole != null)
         {
             setAttribute(MUC_ROLE_ATTR_NAME, b.mucRole.toString());
+        }
+
+        if (b.diarize != null)
+        {
+            setAttribute(DIARIZE_ATTR_NAME, b.diarize);
         }
 
         if (b.forceMute != null)
@@ -107,6 +117,16 @@ public class Colibri2Endpoint
     public @Nullable MUCRole getMucRole()
     {
         return MUCRole.fromString(getAttributeAsString(MUC_ROLE_ATTR_NAME));
+    }
+
+    /**
+     * Get whether this endpoint's audio should be diarized. Returns null if the attribute is absent, in which case
+     * the default should be used.
+     */
+    public @Nullable Boolean getDiarize()
+    {
+        String diarize = getAttributeAsString(DIARIZE_ATTR_NAME);
+        return diarize == null ? null : Boolean.parseBoolean(diarize);
     }
 
     /**
@@ -167,6 +187,11 @@ public class Colibri2Endpoint
         private MUCRole mucRole;
 
         /**
+         * Whether the endpoint being built should have its audio diarized.
+         */
+        private Boolean diarize;
+
+        /**
          * The force-mute element of the endpoint being built.
          */
         @Nullable private ForceMute forceMute = null;
@@ -200,6 +225,16 @@ public class Colibri2Endpoint
         public Builder setMucRole(MUCRole mucRole)
         {
             this.mucRole = mucRole;
+
+            return this;
+        }
+
+        /**
+         * Set whether the endpoint being built should have its audio diarized.
+         */
+        public Builder setDiarize(boolean diarize)
+        {
+            this.diarize = diarize;
 
             return this;
         }

--- a/src/test/java/org/jitsi/xmpp/extensions/colibri2/Colibri2EndpointTest.java
+++ b/src/test/java/org/jitsi/xmpp/extensions/colibri2/Colibri2EndpointTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright @ 2021 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.xmpp.extensions.colibri2;
+
+import org.jivesoftware.smack.util.*;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Colibri2EndpointTest
+{
+    @Test
+    public void diarizeRoundTripTest()
+            throws Exception
+    {
+        Colibri2Endpoint.Provider provider = new Colibri2Endpoint.Provider();
+
+        // Set via builder -> serialize -> parse -> getDiarize() == true
+        Colibri2Endpoint.Builder builder = Colibri2Endpoint.getBuilder();
+        builder.setId("endpoint-id");
+        builder.setDiarize(true);
+        Colibri2Endpoint built = builder.build();
+        assertEquals(Boolean.TRUE, built.getDiarize());
+
+        Colibri2Endpoint parsed = provider.parse(PacketParserUtils.getParserFor(built.toXML().toString()));
+        assertEquals(Boolean.TRUE, parsed.getDiarize());
+
+        // diarize=false round-trips as false.
+        Colibri2Endpoint.Builder builderFalse = Colibri2Endpoint.getBuilder();
+        builderFalse.setId("endpoint-id");
+        builderFalse.setDiarize(false);
+        Colibri2Endpoint builtFalse = builderFalse.build();
+        assertEquals(Boolean.FALSE, builtFalse.getDiarize());
+        assertEquals(Boolean.FALSE,
+                provider.parse(PacketParserUtils.getParserFor(builtFalse.toXML().toString())).getDiarize());
+    }
+
+    @Test
+    public void diarizeAbsentTest()
+            throws Exception
+    {
+        Colibri2Endpoint.Provider provider = new Colibri2Endpoint.Provider();
+
+        // Absent attribute -> null (fall back to default).
+        Colibri2Endpoint.Builder builder = Colibri2Endpoint.getBuilder();
+        builder.setId("endpoint-id");
+        Colibri2Endpoint built = builder.build();
+        assertNull(built.getDiarize());
+
+        Colibri2Endpoint parsed = provider.parse(PacketParserUtils.getParserFor(built.toXML().toString()));
+        assertNull(parsed.getDiarize());
+    }
+}


### PR DESCRIPTION
Adds a per-endpoint `diarize` boolean **attribute** to the COLIBRI v2 `Colibri2Endpoint` (modeled like the existing `stats-id` / `muc-role` attributes, not a `<capability>` — this is an instruction to the bridge, not a "supports" advertisement). `getDiarize()` returns a nullable `Boolean` (absent = null); `Builder.setDiarize(boolean)` sets it.

Part of a multi-repo change enabling per-endpoint speaker diarization (jicofo signals it here, the videobridge reads it and sets it on the transcriber `start` event). The four Maven repos share the branch `diarization-endpoint-control` so CI builds them together; no dependency version bumps are included (those follow after the upstream repos are released).

---

**Related PRs** (per-endpoint speaker diarization, multi-repo):
- jitsi-meet: jitsi/jitsi-meet#17614
- jitsi-xmpp-extensions: jitsi/jitsi-xmpp-extensions#145
- jicoco: jitsi/jicoco#238
- jicofo: jitsi/jicofo#1291
- jitsi-videobridge: jitsi/jitsi-videobridge#2431
- opus-transcriber-proxy: jitsi/opus-transcriber-proxy#106
