### PR TITLE
Add TraceParent extension

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/colibri2/IqProviderUtils.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri2/IqProviderUtils.java
@@ -183,5 +183,9 @@ public class IqProviderUtils
         ProviderManager.addExtensionProvider(Colibri2Error.ELEMENT,
                 Colibri2Error.NAMESPACE,
                 new Colibri2Error.Provider());
+
+        ProviderManager.addExtensionProvider(TraceParent.ELEMENT,
+                                             TraceParent.NAMESPACE,
+                                             new TraceParentProvider());
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri2/IqProviderUtils.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri2/IqProviderUtils.java
@@ -185,7 +185,7 @@ public class IqProviderUtils
                 new Colibri2Error.Provider());
 
         ProviderManager.addExtensionProvider(TraceParent.ELEMENT,
-                                             TraceParent.NAMESPACE,
-                                             new TraceParentProvider());
+                 TraceParent.NAMESPACE,
+                 new TraceParentProvider());
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri2/IqProviderUtils.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri2/IqProviderUtils.java
@@ -183,5 +183,7 @@ public class IqProviderUtils
         ProviderManager.addExtensionProvider(Colibri2Error.ELEMENT,
                 Colibri2Error.NAMESPACE,
                 new Colibri2Error.Provider());
+
+        ProviderManager.addExtensionProvider(TraceParent.ELEMENT, TraceParent.NAMESPACE, new TraceParentProvider());
     }
 }

--- a/src/main/java/org/jitsi/xmpp/extensions/colibri2/IqProviderUtils.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri2/IqProviderUtils.java
@@ -183,7 +183,5 @@ public class IqProviderUtils
         ProviderManager.addExtensionProvider(Colibri2Error.ELEMENT,
                 Colibri2Error.NAMESPACE,
                 new Colibri2Error.Provider());
-
-        ProviderManager.addExtensionProvider(TraceParent.ELEMENT, TraceParent.NAMESPACE, new TraceParentProvider());
     }
 }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/TraceParent.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/TraceParent.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright @ 2023 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jitsi.xmpp.extensions
 
 import org.jivesoftware.smack.packet.XmlEnvironment
@@ -7,17 +22,20 @@ import org.jivesoftware.smack.xml.XmlPullParser
 import org.jivesoftware.smack.xml.XmlPullParserException
 import java.io.IOException
 
-class TraceParent(val traceId: String, val parentId: String) : AbstractPacketExtension(NAMESPACE, ELEMENT) {
+class TraceParent(val traceId: String, val parentId: String, val traceFlags: String) :
+    AbstractPacketExtension(NAMESPACE, ELEMENT) {
     init {
         setAttribute(TRACE_ID_ATTR_NAME, traceId)
         setAttribute(PARENT_ID_ATTR_NAME, parentId)
+        setAttribute(TRACE_FLAGS_ATTR_NAME, traceFlags)
     }
 
     companion object {
         const val ELEMENT = "traceparent"
-        const val NAMESPACE = "opentelemetry"
+        const val NAMESPACE = "jitsi:opentelemetry"
         const val TRACE_ID_ATTR_NAME = "trace_id"
         const val PARENT_ID_ATTR_NAME = "parent_id"
+        const val TRACE_FLAGS_ATTR_NAME = "trace_flags"
     }
 }
 
@@ -32,6 +50,10 @@ class TraceParentProvider : ExtensionElementProvider<TraceParent>() {
             ?: throw SmackParsingException.RequiredAttributeMissingException(
                 "Missing '${TraceParent.PARENT_ID_ATTR_NAME}' attribute"
             )
-        return TraceParent(traceId, parentId)
+        val traceFlags = parser.getAttributeValue("", TraceParent.TRACE_FLAGS_ATTR_NAME)
+            ?: throw SmackParsingException.RequiredAttributeMissingException(
+                "Missing '${TraceParent.TRACE_FLAGS_ATTR_NAME}' attribute"
+            )
+        return TraceParent(traceId, parentId, traceFlags)
     }
 }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/TraceParent.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/TraceParent.kt
@@ -1,0 +1,37 @@
+package org.jitsi.xmpp.extensions
+
+import org.jivesoftware.smack.packet.XmlEnvironment
+import org.jivesoftware.smack.parsing.SmackParsingException
+import org.jivesoftware.smack.provider.ExtensionElementProvider
+import org.jivesoftware.smack.xml.XmlPullParser
+import org.jivesoftware.smack.xml.XmlPullParserException
+import java.io.IOException
+
+class TraceParent(val traceId: String, val parentId: String) : AbstractPacketExtension(NAMESPACE, ELEMENT) {
+    init {
+        setAttribute(TRACE_ID_ATTR_NAME, traceId)
+        setAttribute(PARENT_ID_ATTR_NAME, parentId)
+    }
+
+    companion object {
+        const val ELEMENT = "traceparent"
+        const val NAMESPACE = "opentelemetry"
+        const val TRACE_ID_ATTR_NAME = "trace_id"
+        const val PARENT_ID_ATTR_NAME = "parent_id"
+    }
+}
+
+class TraceParentProvider : ExtensionElementProvider<TraceParent>() {
+    @Throws(XmlPullParserException::class, IOException::class, SmackParsingException::class)
+    override fun parse(parser: XmlPullParser, depth: Int, xml: XmlEnvironment?): TraceParent {
+        val traceId = parser.getAttributeValue("", TraceParent.TRACE_ID_ATTR_NAME)
+            ?: throw SmackParsingException.RequiredAttributeMissingException(
+                "Missing '${TraceParent.TRACE_ID_ATTR_NAME}' attribute"
+            )
+        val parentId = parser.getAttributeValue("", TraceParent.PARENT_ID_ATTR_NAME)
+            ?: throw SmackParsingException.RequiredAttributeMissingException(
+                "Missing '${TraceParent.PARENT_ID_ATTR_NAME}' attribute"
+            )
+        return TraceParent(traceId, parentId)
+    }
+}

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/TraceParentTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/TraceParentTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright @ 2024 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.xmpp.extensions
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.jitsi.xmpp.extensions.colibri2.IqProviderUtils
+import org.jivesoftware.smack.parsing.SmackParsingException
+import org.jivesoftware.smack.util.PacketParserUtils
+
+class TraceParentTest : ShouldSpec() {
+    init {
+        IqProviderUtils.registerProviders()
+        val provider = TraceParentProvider()
+
+        context("Parsing a valid extension") {
+            val traceParent = provider.parse(
+                PacketParserUtils.getParserFor(
+                    "<trace trace_id='1586bb16ccd4475a9f494bf43563ce28' parent_id='6e39899d78bfa0ae' trace_flags='35'/>"
+                )
+            )
+
+            traceParent.traceId shouldBe "1586bb16ccd4475a9f494bf43563ce28"
+            traceParent.parentId shouldBe "6e39899d78bfa0ae"
+            traceParent.traceFlags shouldBe "35"
+        }
+
+        context("Parsing with missing traceId") {
+            shouldThrow<SmackParsingException> {
+                provider.parse(
+                    PacketParserUtils.getParserFor(
+                        "<trace parent_id='6e39899d78bfa0ae' trace_flags='35'/>"
+                    )
+                )
+            }
+        }
+
+        context("Parsing with missing parentId") {
+            shouldThrow<SmackParsingException> {
+                provider.parse(
+                    PacketParserUtils.getParserFor(
+                        "<trace trace_id='1586bb16ccd4475a9f494bf43563ce28' trace_flags='35'/>"
+                    )
+                )
+            }
+        }
+
+        context("Parsing with missing traceFlags") {
+            shouldThrow<SmackParsingException> {
+                provider.parse(
+                    PacketParserUtils.getParserFor(
+                        "<trace trace_id='1586bb16ccd4475a9f494bf43563ce28' parent_id='6e39899d78bfa0ae'/>"
+                    )
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/TraceParentTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/TraceParentTest.kt
@@ -30,7 +30,8 @@ class TraceParentTest : ShouldSpec() {
         context("Parsing a valid extension") {
             val traceParent = provider.parse(
                 PacketParserUtils.getParserFor(
-                    "<trace trace_id='1586bb16ccd4475a9f494bf43563ce28' parent_id='6e39899d78bfa0ae' trace_flags='35'/>"
+                    "<traceparent trace_id='1586bb16ccd4475a9f494bf43563ce28' " +
+                        "parent_id='6e39899d78bfa0ae' trace_flags='35'/>"
                 )
             )
 
@@ -43,7 +44,7 @@ class TraceParentTest : ShouldSpec() {
             shouldThrow<SmackParsingException> {
                 provider.parse(
                     PacketParserUtils.getParserFor(
-                        "<trace parent_id='6e39899d78bfa0ae' trace_flags='35'/>"
+                        "<traceparent parent_id='6e39899d78bfa0ae' trace_flags='35'/>"
                     )
                 )
             }
@@ -53,7 +54,7 @@ class TraceParentTest : ShouldSpec() {
             shouldThrow<SmackParsingException> {
                 provider.parse(
                     PacketParserUtils.getParserFor(
-                        "<trace trace_id='1586bb16ccd4475a9f494bf43563ce28' trace_flags='35'/>"
+                        "<traceparent trace_id='1586bb16ccd4475a9f494bf43563ce28' trace_flags='35'/>"
                     )
                 )
             }
@@ -63,7 +64,8 @@ class TraceParentTest : ShouldSpec() {
             shouldThrow<SmackParsingException> {
                 provider.parse(
                     PacketParserUtils.getParserFor(
-                        "<trace trace_id='1586bb16ccd4475a9f494bf43563ce28' parent_id='6e39899d78bfa0ae'/>"
+                        "<traceparent trace_id='1586bb16ccd4475a9f494bf43563ce28' " +
+                            "parent_id='6e39899d78bfa0ae'/>"
                     )
                 )
             }

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/ConferenceModifyIQTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/ConferenceModifyIQTest.kt
@@ -18,12 +18,16 @@ package org.jitsi.xmpp.extensions.colibri2
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.jitsi.xmpp.extensions.IQUtils
+import org.jitsi.xmpp.extensions.TraceParent
 import org.jivesoftware.smack.parsing.SmackParsingException
 
 class ConferenceModifyIQTest : ShouldSpec() {
     val provider = ConferenceModifyIQProvider()
     init {
+        IqProviderUtils.registerProviders()
+
         context("Parse a simple IQ correctly") {
             val conferenceModifyIQ = IQUtils.parse(
                 """
@@ -58,6 +62,20 @@ class ConferenceModifyIQTest : ShouldSpec() {
                     provider
                 )
             }
+        }
+        context("Parse IQ with TraceParent extension") {
+            val conferenceModifyIQ = IQUtils.parse(
+                """
+                    <iq type='get' from='example.com' to='example.com'>
+                        <conference-modify xmlns='http://jitsi.org/protocol/colibri2' meeting-id='abc'>
+                            <traceparent xmlns='jitsi:opentelemetry' trace_id='1586bb16ccd4475a9f494bf43563ce28'
+                            parent_id='6e39899d78bfa0ae' trace_flags='35'/>
+                        </conference-modify>
+                    </iq>
+                """.trimIndent(),
+                provider
+            )
+            conferenceModifyIQ.getExtension(TraceParent::class.java) shouldNotBe null
         }
     }
 }


### PR DESCRIPTION
Adds `TraceParent` XMPP extension for propagating trace context: trace id, parent span id, and trace flags.

Related to the tracing backend GSoC project: https://summerofcode.withgoogle.com/programs/2026/projects/GseggmSv