### PR TITLE
Fix Jibri IQ extension parsing

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jibri/JibriIqProvider.java
@@ -18,6 +18,7 @@ package org.jitsi.xmpp.extensions.jibri;
 import org.apache.commons.lang3.StringUtils;
 
 import org.jitsi.xmpp.extensions.*;
+import org.jitsi.xmpp.extensions.colibri2.IqProviderUtils;
 import org.jivesoftware.smack.packet.*;
 import org.jivesoftware.smack.util.*;
 import org.jivesoftware.smack.xml.*;
@@ -133,8 +134,7 @@ public class JibriIqProvider
         {
             return null;
         }
-
-        ParserUtils.forwardToEndTagOfDepth(parser, initialDepth);
+        IqProviderUtils.parseExtensions(parser, initialDepth, iq);
         return iq;
     }
 }

--- a/src/test/java/org/jitsi/xmpp/extensions/jibri/JibriIqProviderTest.java
+++ b/src/test/java/org/jitsi/xmpp/extensions/jibri/JibriIqProviderTest.java
@@ -18,6 +18,7 @@ package org.jitsi.xmpp.extensions.jibri;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.jitsi.xmpp.extensions.*;
+import org.jitsi.xmpp.extensions.colibri2.*;
 import org.jivesoftware.smack.packet.*;
 import org.junit.jupiter.api.*;
 
@@ -28,6 +29,12 @@ import org.junit.jupiter.api.*;
  */
 public class JibriIqProviderTest
 {
+    @BeforeAll
+    public static void registerProviders()
+    {
+        IqProviderUtils.registerProviders();
+    }
+
     @Test
     public void testParseIQ()
         throws Exception
@@ -106,5 +113,27 @@ public class JibriIqProviderTest
 
         iq.setRtcStatsEnabled(null);
         assertFalse(iq.toXML().toString().contains("rtcstats_enabled"));
+    }
+
+    @Test
+    public void testParseExtension()
+        throws Exception
+    {
+        JibriIqProvider provider = new JibriIqProvider();
+
+        String iqXml =
+            "<iq to='t' from='f' type='set'>" +
+                "<jibri xmlns='http://jitsi.org/protocol/jibri'" +
+                "   action='start'>" +
+                "<capability xmlns='jitsi:colibri2' name='cap1'/>" +
+                "</jibri>" +
+                "</iq>";
+
+        JibriIq jibriIq = IQUtils.parse(iqXml, provider);
+
+        assertNotNull(jibriIq);
+        Capability capability = jibriIq.getExtension(Capability.class);
+        assertNotNull(capability, "extension must be attached to the parsed IQ");
+        assertEquals("cap1", capability.getName());
     }
 }


### PR DESCRIPTION
This PR adds support for carrying extensions inside a `JibriIQ` stanza, by replacing `forwardToEndTagOfDepth` with `parseExtensions`. This is required in order to attach `TraceParentExtension`, so as to propagate tracing context in Jibri requests.