### PR TITLE
feat: Add wire-format attributes for in-place ICE restart

### DIFF
--- a/src/main/java/org/jitsi/xmpp/extensions/colibri2/Transport.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/colibri2/Transport.java
@@ -60,6 +60,18 @@ public class Transport
     public static final boolean USE_UNIQUE_PORT_DEFAULT = false;
 
     /**
+     * The name of the <tt>ice-restart</tt> attribute. Set in a conference-modify request to ask the bridge to restart
+     * ICE for the endpoint, i.e. to create a new ICE agent with fresh credentials while the existing one keeps
+     * carrying media until the new one is connected (make-before-break).
+     */
+    public static final String ICE_RESTART_ATTR_NAME = "ice-restart";
+
+    /**
+     * Default value for the ice-restart attribute.
+     */
+    public static final boolean ICE_RESTART_DEFAULT = false;
+
+    /**
      * Construct a Transport.  Needs to be public for DefaultPacketExtensionProvider to work.
      */
     public Transport()
@@ -82,6 +94,11 @@ public class Transport
         if (b.useUniquePort != USE_UNIQUE_PORT_DEFAULT)
         {
             setAttribute(USE_UNIQUE_PORT_ATTR_NAME, b.useUniquePort);
+        }
+
+        if (b.iceRestart != ICE_RESTART_DEFAULT)
+        {
+            setAttribute(ICE_RESTART_ATTR_NAME, b.iceRestart);
         }
 
         if (b.iceUdpExtension != null)
@@ -127,6 +144,15 @@ public class Transport
     }
 
     /**
+     * Gets whether an ICE restart is being requested. Only meaningful in a conference-modify request.
+     */
+    public boolean getIceRestart()
+    {
+        String iceRestart = getAttributeAsString(ICE_RESTART_ATTR_NAME);
+        return iceRestart == null ? ICE_RESTART_DEFAULT : Boolean.parseBoolean(iceRestart);
+    }
+
+    /**
      * Return the contained ICE UDP Transport object, or null.
      */
     public @Nullable IceUdpTransportPacketExtension getIceUdpTransport()
@@ -158,6 +184,8 @@ public class Transport
 
         private boolean iceControlling = ICE_CONTROLLING_DEFAULT;
 
+        private boolean iceRestart = ICE_RESTART_DEFAULT;
+
         private IceUdpTransportPacketExtension iceUdpExtension;
 
         private Sctp sctp;
@@ -177,6 +205,12 @@ public class Transport
         public Builder setIceControlling(boolean i)
         {
             this.iceControlling = i;
+            return this;
+        }
+
+        public Builder setIceRestart(boolean iceRestart)
+        {
+            this.iceRestart = iceRestart;
             return this;
         }
 

--- a/src/main/java/org/jitsi/xmpp/extensions/jingle/IceUdpTransportPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jingle/IceUdpTransportPacketExtension.java
@@ -53,6 +53,21 @@ public class IceUdpTransportPacketExtension
     public static final String UFRAG_ATTR_NAME = "ufrag";
 
     /**
+     * The name of the <tt>ice-generation</tt> attribute, which tags a set of ICE credentials with the
+     * ICE restart round they belong to. It is allocated and incremented by the side that initiates the
+     * restart, and echoed back by the peer when it signals its own rotated credentials for the same
+     * round, so that concurrent or reordered restarts can be matched up and stale ones discarded.
+     * Absent means generation {@link #GENERATION_UNSPECIFIED} (a peer that predates this attribute).
+     */
+    public static final String ICE_GENERATION_ATTR_NAME = "ice-generation";
+
+    /**
+     * The value returned by {@link #getIceGeneration()} when the <tt>ice-generation</tt> attribute is
+     * absent, i.e. when the peer does not support generation tagging.
+     */
+    public static final int GENERATION_UNSPECIFIED = -1;
+
+    /**
      * A list of one or more candidates representing each of the initiator's
      * higher-priority transport candidates as determined in accordance with
      * the ICE methodology.
@@ -129,6 +144,28 @@ public class IceUdpTransportPacketExtension
     public String getUfrag()
     {
         return super.getAttributeAsString(UFRAG_ATTR_NAME);
+    }
+
+    /**
+     * Sets the ICE restart generation that the credentials in this element belong to.
+     *
+     * @param generation the ICE restart generation.
+     */
+    public void setIceGeneration(int generation)
+    {
+        super.setAttribute(ICE_GENERATION_ATTR_NAME, generation);
+    }
+
+    /**
+     * Returns the ICE restart generation that the credentials in this element belong to, or
+     * {@link #GENERATION_UNSPECIFIED} if the attribute is absent (the peer does not support
+     * generation tagging).
+     *
+     * @return the ICE restart generation, or {@link #GENERATION_UNSPECIFIED} if absent.
+     */
+    public int getIceGeneration()
+    {
+        return super.getAttributeAsInt(ICE_GENERATION_ATTR_NAME, GENERATION_UNSPECIFIED);
     }
 
     /**

--- a/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/BridgeSessionPacketExtension.java
+++ b/src/main/java/org/jitsi/xmpp/extensions/jitsimeet/BridgeSessionPacketExtension.java
@@ -55,6 +55,14 @@ public class BridgeSessionPacketExtension
     private static final String RESTART_ATTR_NAME = "restart";
 
     /**
+     * The name for the "ice-restart" attribute. The {@code BridgeSessionPacketExtension} is included in
+     * 'session-info' sent by the client to Jicofo. If this attribute is set to {@code true} the client is asking for
+     * the ICE connection to the bridge to be restarted in place, keeping the existing session (as opposed to the
+     * {@link #RESTART_ATTR_NAME} flag, which asks for the whole session to be re-created).
+     */
+    private static final String ICE_RESTART_ATTR_NAME = "ice-restart";
+
+    /**
      * Creates new instance of {@code BridgeSessionPacketExtension}.
      */
     public BridgeSessionPacketExtension()
@@ -101,6 +109,23 @@ public class BridgeSessionPacketExtension
     public void setRestart(Boolean restart)
     {
         setAttribute(RESTART_ATTR_NAME, restart);
+    }
+
+    /**
+     * @return the value of {@link #ICE_RESTART_ATTR_NAME}, {@code false} if not set.
+     */
+    public Boolean isIceRestart()
+    {
+        return Boolean.parseBoolean(getAttributeAsString(ICE_RESTART_ATTR_NAME));
+    }
+
+    /**
+     * Sets new value for {@link #ICE_RESTART_ATTR_NAME}.
+     * @param iceRestart the new value to set or {@code null} to remove.
+     */
+    public void setIceRestart(Boolean iceRestart)
+    {
+        setAttribute(ICE_RESTART_ATTR_NAME, iceRestart);
     }
 
     /**


### PR DESCRIPTION
Wire-format additions for an in-place ICE restart, in which the bridge creates a new ICE agent with fresh credentials while the existing one keeps carrying media until the new one connects (make-before-break).

- `IceUdpTransportPacketExtension`: `ice-generation` attribute (`GENERATION_UNSPECIFIED = -1` when absent). The bridge owns and increments this counter; it lets jicofo drop reordered colibri2 responses and lets both the client and the bridge discard superseded restart rounds.
- colibri2 `Transport`: `ice-restart` attribute, set by jicofo in a conference-modify to ask the bridge to restart ICE for an endpoint.
- `BridgeSessionPacketExtension`: `ice-restart` attribute, set by the client in a Jingle `session-info` to ask jicofo for the restart. Distinct from the existing `restart` flag, which asks for the whole session to be re-created.

Part of a multi-repo change; all PRs share the `in-place-ice-restart` branch name so CI tests them together:

- jitsi-videobridge: https://github.com/jitsi/jitsi-videobridge/pull/2438
- jicofo: https://github.com/jitsi/jicofo/pull/1299
- lib-jitsi-meet: https://github.com/jitsi/lib-jitsi-meet/pull/3083
- jitsi-meet: https://github.com/jitsi/jitsi-meet/pull/17700
