### PR TITLE
feat: Add a client-requirements IQ.

### DIFF
--- a/src/main/kotlin/org/jitsi/xmpp/extensions/StringValueEnum.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/StringValueEnum.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright @ 2026 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.xmpp.extensions
+
+/**
+ * An enum whose entries have a string value which is used on the wire.
+ */
+interface StringValueEnum {
+    val value: String
+}
+
+/**
+ * Find the entry of [T] whose [StringValueEnum.value] is [s], or return null if there is no such entry.
+ */
+inline fun <reified T> parseStringValue(s: String): T? where T : Enum<T>, T : StringValueEnum =
+    enumValues<T>().find { it.value == s }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/clientrequirements/ClientRequirementsIq.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/clientrequirements/ClientRequirementsIq.kt
@@ -16,7 +16,9 @@
 package org.jitsi.xmpp.extensions.clientrequirements
 
 import org.jitsi.xmpp.extensions.SafeParseIqProvider
+import org.jitsi.xmpp.extensions.StringValueEnum
 import org.jitsi.xmpp.extensions.colibri2.IqProviderUtils
+import org.jitsi.xmpp.extensions.parseStringValue
 import org.jivesoftware.smack.XMPPConnection
 import org.jivesoftware.smack.packet.IQ
 import org.jivesoftware.smack.packet.IqBuilder
@@ -29,7 +31,7 @@ import org.jivesoftware.smack.xml.XmlPullParser
 /**
  * What the sender of a [ClientRequirementsIq] does about the missing features.
  */
-enum class RequirementsAction(val value: String) {
+enum class RequirementsAction(override val value: String) : StringValueEnum {
     /** At least one feature with a "hard" level is missing, and the endpoint will not be invited. */
     REJECT("reject"),
 
@@ -37,7 +39,7 @@ enum class RequirementsAction(val value: String) {
     WARN("warn");
 
     companion object {
-        fun parseString(s: String): RequirementsAction? = entries.find { it.value == s }
+        fun parseString(s: String): RequirementsAction? = parseStringValue<RequirementsAction>(s)
     }
 }
 

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/clientrequirements/ClientRequirementsIq.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/clientrequirements/ClientRequirementsIq.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright @ 2026 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.xmpp.extensions.clientrequirements
+
+import org.jitsi.xmpp.extensions.SafeParseIqProvider
+import org.jitsi.xmpp.extensions.colibri2.IqProviderUtils
+import org.jivesoftware.smack.XMPPConnection
+import org.jivesoftware.smack.packet.IQ
+import org.jivesoftware.smack.packet.IqBuilder
+import org.jivesoftware.smack.packet.IqData
+import org.jivesoftware.smack.packet.XmlEnvironment
+import org.jivesoftware.smack.parsing.SmackParsingException
+import org.jivesoftware.smack.provider.ProviderManager
+import org.jivesoftware.smack.xml.XmlPullParser
+
+/**
+ * What the sender of a [ClientRequirementsIq] does about the missing features.
+ */
+enum class RequirementsAction(val value: String) {
+    /** At least one feature with a "hard" level is missing, and the endpoint will not be invited. */
+    REJECT("reject"),
+
+    /** Only features with a "soft" level are missing. The endpoint is invited as usual. */
+    WARN("warn");
+
+    companion object {
+        fun parseString(s: String): RequirementsAction? = entries.find { it.value == s }
+    }
+}
+
+/**
+ * Sent by jicofo to a client which does not advertise all the features that the deployment requires. Sent as an IQ of
+ * type "set" from the focus' occupant JID to the client's occupant JID. Clients which support it advertise the
+ * "http://jitsi.org/client-requirements-1" feature.
+ */
+class ClientRequirementsIq private constructor(b: Builder) : IQ(b, ELEMENT, NAMESPACE) {
+    val action: RequirementsAction = b.action ?: throw IllegalArgumentException("The 'action' attribute must be set")
+
+    override fun getIQChildElementBuilder(xml: IQChildElementXmlStringBuilder) = xml.apply {
+        attribute(ACTION_ATTR_NAME, action.value)
+        rightAngleBracket()
+    }
+
+    val missingFeatures: List<MissingFeatureExtension>
+        get() = getExtensions(MissingFeatureExtension::class.java)
+
+    companion object {
+        const val NAMESPACE = "jitsi:client-requirements"
+        const val ELEMENT = "client-requirements"
+        const val ACTION_ATTR_NAME = "action"
+
+        /** The feature advertised by clients which understand this IQ. */
+        const val FEATURE = "http://jitsi.org/client-requirements-1"
+
+        fun registerProviders() {
+            ProviderManager.addIQProvider(ELEMENT, NAMESPACE, ClientRequirementsIqProvider())
+            ProviderManager.addExtensionProvider(
+                MissingFeatureExtension.ELEMENT,
+                NAMESPACE,
+                MissingFeatureExtensionProvider()
+            )
+        }
+    }
+
+    class Builder : IqBuilder<Builder, ClientRequirementsIq> {
+        constructor(id: String) : super(id)
+        constructor(connection: XMPPConnection) : super(connection)
+        constructor(iqCommon: IqData) : super(iqCommon)
+
+        var action: RequirementsAction? = null
+
+        override fun build(): ClientRequirementsIq = ClientRequirementsIq(this)
+
+        override fun getThis() = this
+    }
+}
+
+class ClientRequirementsIqProvider : SafeParseIqProvider<ClientRequirementsIq>() {
+    @Throws(Exception::class)
+    override fun doParse(
+        parser: XmlPullParser,
+        initialDepth: Int,
+        data: IqData,
+        xmlEnvironment: XmlEnvironment
+    ): ClientRequirementsIq? {
+        if (parser.namespace != ClientRequirementsIq.NAMESPACE || parser.name != ClientRequirementsIq.ELEMENT) {
+            return null
+        }
+
+        val actionString = parser.getAttributeValue("", ClientRequirementsIq.ACTION_ATTR_NAME)
+            ?: throw SmackParsingException.RequiredAttributeMissingException("Missing 'action' attribute")
+
+        return ClientRequirementsIq.Builder(data).apply {
+            action = RequirementsAction.parseString(actionString)
+                ?: throw SmackParsingException("Invalid 'action' attribute: $actionString")
+            addExtensions(IqProviderUtils.parseExtensions(parser, initialDepth))
+        }.build()
+    }
+}

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/clientrequirements/MissingFeatureExtension.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/clientrequirements/MissingFeatureExtension.kt
@@ -16,6 +16,8 @@
 package org.jitsi.xmpp.extensions.clientrequirements
 
 import org.jitsi.xmpp.extensions.AbstractPacketExtension
+import org.jitsi.xmpp.extensions.StringValueEnum
+import org.jitsi.xmpp.extensions.parseStringValue
 import org.jivesoftware.smack.packet.XmlEnvironment
 import org.jivesoftware.smack.parsing.SmackParsingException
 import org.jivesoftware.smack.provider.ExtensionElementProvider
@@ -26,7 +28,7 @@ import java.io.IOException
 /**
  * The severity of a missing feature.
  */
-enum class RequirementLevel(val value: String) {
+enum class RequirementLevel(override val value: String) : StringValueEnum {
     /** The endpoint is not invited to the conference. */
     HARD("hard"),
 
@@ -34,7 +36,7 @@ enum class RequirementLevel(val value: String) {
     SOFT("soft");
 
     companion object {
-        fun parseString(s: String): RequirementLevel? = entries.find { it.value == s }
+        fun parseString(s: String): RequirementLevel? = parseStringValue<RequirementLevel>(s)
     }
 }
 
@@ -74,7 +76,9 @@ class MissingFeatureExtension(
 class MissingFeatureExtensionProvider : ExtensionElementProvider<MissingFeatureExtension>() {
     @Throws(XmlPullParserException::class, IOException::class, SmackParsingException::class)
     override fun parse(parser: XmlPullParser, depth: Int, xml: XmlEnvironment?): MissingFeatureExtension {
+        // Note that getAttributeValue returns an empty string when the attribute is present but empty.
         val feature = parser.getAttributeValue("", MissingFeatureExtension.FEATURE_ATTR_NAME)
+            ?.takeIf { it.isNotBlank() }
             ?: throw SmackParsingException.RequiredAttributeMissingException("Missing 'var' attribute")
         val levelString = parser.getAttributeValue("", MissingFeatureExtension.LEVEL_ATTR_NAME)
             ?: throw SmackParsingException.RequiredAttributeMissingException("Missing 'level' attribute")

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/clientrequirements/MissingFeatureExtension.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/clientrequirements/MissingFeatureExtension.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright @ 2026 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.xmpp.extensions.clientrequirements
+
+import org.jitsi.xmpp.extensions.AbstractPacketExtension
+import org.jivesoftware.smack.packet.XmlEnvironment
+import org.jivesoftware.smack.parsing.SmackParsingException
+import org.jivesoftware.smack.provider.ExtensionElementProvider
+import org.jivesoftware.smack.xml.XmlPullParser
+import org.jivesoftware.smack.xml.XmlPullParserException
+import java.io.IOException
+
+/**
+ * The severity of a missing feature.
+ */
+enum class RequirementLevel(val value: String) {
+    /** The endpoint is not invited to the conference. */
+    HARD("hard"),
+
+    /** The endpoint is invited, but the feature is expected to be present. */
+    SOFT("soft");
+
+    companion object {
+        fun parseString(s: String): RequirementLevel? = entries.find { it.value == s }
+    }
+}
+
+/**
+ * Describes one feature that a client is required to advertise, but does not.
+ */
+class MissingFeatureExtension(
+    /** The feature (XEP-0030 "var"), e.g. "http://jitsi.org/ssrc-rewriting-1". */
+    val feature: String,
+    /** A stable symbolic name for the feature, e.g. "SSRC_REWRITING_V1". Clients may use it as a translation key. */
+    val name: String?,
+    val level: RequirementLevel,
+    /** Human readable text (in English) which describes how to add support for the feature. */
+    val details: String?,
+    /** A URL with more information. */
+    val url: String?
+) : AbstractPacketExtension(NAMESPACE, ELEMENT) {
+    init {
+        setAttribute(FEATURE_ATTR_NAME, feature)
+        name?.let { setAttribute(NAME_ATTR_NAME, it) }
+        setAttribute(LEVEL_ATTR_NAME, level.value)
+        details?.let { setAttribute(DETAILS_ATTR_NAME, it) }
+        url?.let { setAttribute(URL_ATTR_NAME, it) }
+    }
+
+    companion object {
+        const val ELEMENT = "missing-feature"
+        const val NAMESPACE = ClientRequirementsIq.NAMESPACE
+        const val FEATURE_ATTR_NAME = "var"
+        const val NAME_ATTR_NAME = "name"
+        const val LEVEL_ATTR_NAME = "level"
+        const val DETAILS_ATTR_NAME = "details"
+        const val URL_ATTR_NAME = "url"
+    }
+}
+
+class MissingFeatureExtensionProvider : ExtensionElementProvider<MissingFeatureExtension>() {
+    @Throws(XmlPullParserException::class, IOException::class, SmackParsingException::class)
+    override fun parse(parser: XmlPullParser, depth: Int, xml: XmlEnvironment?): MissingFeatureExtension {
+        val feature = parser.getAttributeValue("", MissingFeatureExtension.FEATURE_ATTR_NAME)
+            ?: throw SmackParsingException.RequiredAttributeMissingException("Missing 'var' attribute")
+        val levelString = parser.getAttributeValue("", MissingFeatureExtension.LEVEL_ATTR_NAME)
+            ?: throw SmackParsingException.RequiredAttributeMissingException("Missing 'level' attribute")
+        val level = RequirementLevel.parseString(levelString)
+            ?: throw SmackParsingException("Invalid 'level' attribute: $levelString")
+
+        return MissingFeatureExtension(
+            feature = feature,
+            name = parser.getAttributeValue("", MissingFeatureExtension.NAME_ATTR_NAME),
+            level = level,
+            details = parser.getAttributeValue("", MissingFeatureExtension.DETAILS_ATTR_NAME),
+            url = parser.getAttributeValue("", MissingFeatureExtension.URL_ATTR_NAME)
+        )
+    }
+}

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/clientrequirements/ClientRequirementsIqTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/clientrequirements/ClientRequirementsIqTest.kt
@@ -107,6 +107,46 @@ class ClientRequirementsIqTest : ShouldSpec() {
                     )
                 }
             }
+            should("Fail with a missing-feature with no 'level'") {
+                shouldThrow<Exception> {
+                    IQUtils.parse(
+                        """
+<iq to='t' from='f' type='set'>
+    <client-requirements xmlns='jitsi:client-requirements' action='reject'>
+        <missing-feature xmlns='jitsi:client-requirements' var='f'/>
+    </client-requirements>
+</iq>
+                        """.trimIndent(),
+                        provider
+                    )
+                }
+            }
+            should("Fail with a missing-feature with an empty 'var'") {
+                shouldThrow<Exception> {
+                    IQUtils.parse(
+                        """
+<iq to='t' from='f' type='set'>
+    <client-requirements xmlns='jitsi:client-requirements' action='reject'>
+        <missing-feature xmlns='jitsi:client-requirements' var='' level='hard'/>
+    </client-requirements>
+</iq>
+                        """.trimIndent(),
+                        provider
+                    )
+                }
+            }
+            should("Fail with an empty 'action'") {
+                shouldThrow<Exception> {
+                    IQUtils.parse(
+                        """
+<iq to='t' from='f' type='set'>
+    <client-requirements xmlns='jitsi:client-requirements' action=''/>
+</iq>
+                        """.trimIndent(),
+                        provider
+                    )
+                }
+            }
             should("Fail with a missing-feature with an invalid 'level'") {
                 shouldThrow<Exception> {
                     IQUtils.parse(

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/clientrequirements/ClientRequirementsIqTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/clientrequirements/ClientRequirementsIqTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright @ 2026 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.xmpp.extensions.clientrequirements
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.jitsi.xmpp.extensions.IQUtils
+import org.jivesoftware.smack.packet.IQ
+import org.jivesoftware.smack.provider.ProviderManager
+import org.jxmpp.jid.impl.JidCreate
+import org.xmlunit.builder.DiffBuilder
+
+class ClientRequirementsIqTest : ShouldSpec() {
+    init {
+        ClientRequirementsIq.registerProviders()
+        val provider = ProviderManager.getIQProvider(ClientRequirementsIq.ELEMENT, ClientRequirementsIq.NAMESPACE)
+
+        context("Parsing a valid IQ") {
+            IQUtils.parse(validXml, provider).let { iq ->
+                iq.shouldBeInstanceOf<ClientRequirementsIq>()
+                iq.action shouldBe RequirementsAction.REJECT
+                iq.missingFeatures.size shouldBe 2
+                iq.missingFeatures[0].let {
+                    it.feature shouldBe "http://jitsi.org/ssrc-rewriting-1"
+                    it.name shouldBe "SSRC_REWRITING_V1"
+                    it.level shouldBe RequirementLevel.HARD
+                    it.details shouldBe "Update to version 10.2 or later."
+                    it.url shouldBe "https://example.com/docs"
+                }
+                iq.missingFeatures[1].let {
+                    it.feature shouldBe "http://jitsi.org/start-muted-room-metadata"
+                    it.name shouldBe "START_MUTED_RMD"
+                    it.level shouldBe RequirementLevel.SOFT
+                    it.details shouldBe null
+                    it.url shouldBe null
+                }
+            }
+        }
+
+        context("Parsing an IQ with no missing features") {
+            IQUtils.parse(
+                """
+<iq to='t' from='f' type='set'>
+    <client-requirements xmlns='jitsi:client-requirements' action='warn'/>
+</iq>
+                """.trimIndent(),
+                provider
+            ).let { iq ->
+                iq.shouldBeInstanceOf<ClientRequirementsIq>()
+                iq.action shouldBe RequirementsAction.WARN
+                iq.missingFeatures.size shouldBe 0
+            }
+        }
+
+        context("Parsing invalid IQs") {
+            should("Fail with no 'action'") {
+                shouldThrow<Exception> {
+                    IQUtils.parse(
+                        """
+<iq to='t' from='f' type='set'>
+    <client-requirements xmlns='jitsi:client-requirements'/>
+</iq>
+                        """.trimIndent(),
+                        provider
+                    )
+                }
+            }
+            should("Fail with an invalid 'action'") {
+                shouldThrow<Exception> {
+                    IQUtils.parse(
+                        """
+<iq to='t' from='f' type='set'>
+    <client-requirements xmlns='jitsi:client-requirements' action='invalid'/>
+</iq>
+                        """.trimIndent(),
+                        provider
+                    )
+                }
+            }
+            should("Fail with a missing-feature with no 'var'") {
+                shouldThrow<Exception> {
+                    IQUtils.parse(
+                        """
+<iq to='t' from='f' type='set'>
+    <client-requirements xmlns='jitsi:client-requirements' action='reject'>
+        <missing-feature xmlns='jitsi:client-requirements' level='hard'/>
+    </client-requirements>
+</iq>
+                        """.trimIndent(),
+                        provider
+                    )
+                }
+            }
+            should("Fail with a missing-feature with an invalid 'level'") {
+                shouldThrow<Exception> {
+                    IQUtils.parse(
+                        """
+<iq to='t' from='f' type='set'>
+    <client-requirements xmlns='jitsi:client-requirements' action='reject'>
+        <missing-feature xmlns='jitsi:client-requirements' var='f' level='invalid'/>
+    </client-requirements>
+</iq>
+                        """.trimIndent(),
+                        provider
+                    )
+                }
+            }
+        }
+
+        context("Serializing") {
+            val iq = ClientRequirementsIq.Builder("id").apply {
+                action = RequirementsAction.REJECT
+                addExtension(
+                    MissingFeatureExtension(
+                        feature = "http://jitsi.org/ssrc-rewriting-1",
+                        name = "SSRC_REWRITING_V1",
+                        level = RequirementLevel.HARD,
+                        details = "Update to version 10.2 or later.",
+                        url = "https://example.com/docs"
+                    )
+                )
+                addExtension(
+                    MissingFeatureExtension(
+                        feature = "http://jitsi.org/start-muted-room-metadata",
+                        name = "START_MUTED_RMD",
+                        level = RequirementLevel.SOFT,
+                        details = null,
+                        url = null
+                    )
+                )
+                to(JidCreate.from("t"))
+                from(JidCreate.from("f"))
+                ofType(IQ.Type.set)
+            }.build()
+
+            val diff = DiffBuilder.compare(validXml).withTest(iq.toXML().toString()).checkForIdentical().build()
+            diff.hasDifferences() shouldBe false
+        }
+    }
+}
+
+// Whitespace matters.
+private val validXml = "<iq xmlns='jabber:client' to='t' from='f' id='id' type='set'>" +
+    "<client-requirements xmlns='jitsi:client-requirements' action='reject'>" +
+    "<missing-feature xmlns='jitsi:client-requirements' var='http://jitsi.org/ssrc-rewriting-1' " +
+    "name='SSRC_REWRITING_V1' level='hard' details='Update to version 10.2 or later.' " +
+    "url='https://example.com/docs'/>" +
+    "<missing-feature xmlns='jitsi:client-requirements' var='http://jitsi.org/start-muted-room-metadata' " +
+    "name='START_MUTED_RMD' level='soft'/>" +
+    "</client-requirements>" +
+    "</iq>"


### PR DESCRIPTION
Adds the `jitsi:client-requirements` IQ. Jicofo sends this IQ to a client which does not advertise the capabilities that the deployment requires.

The IQ has an `action` of `reject` or `warn`, and one `missing-feature` element for each capability. Each element has a level of `hard` or `soft`, a stable symbolic name, and optional text and URL which tell the user how to add support for the capability.

Set of PRs, all on a branch named `client-capability-requirements`:

- jitsi-xmpp-extensions: https://github.com/jitsi/jitsi-xmpp-extensions/pull/149
- jicofo: https://github.com/jitsi/jicofo/pull/1303
- lib-jitsi-meet: https://github.com/jitsi/lib-jitsi-meet/pull/3091
- jitsi-meet: https://github.com/jitsi/jitsi-meet/pull/17730
