### PR TITLE
Add redaction utility for ConferenceIq token

### DIFF
--- a/src/main/kotlin/org/jitsi/xmpp/util/RedactColibri.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/util/RedactColibri.kt
@@ -62,6 +62,43 @@ class RedactColibri {
             return writer.toString()
         }
 
+        private val redactTokenXslt =
+            """
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:j="jabber:client"
+                xmlns:f="http://jitsi.org/protocol/focus"
+                >
+  <xsl:output method="xml" omit-xml-declaration="yes"/>
+
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match='j:iq/f:conference/@token'>
+    <xsl:attribute name="token">
+      <xsl:value-of select='"[redacted]"'/>
+    </xsl:attribute>
+  </xsl:template>
+</xsl:stylesheet>
+            """
+
+        private val tokenTemplates: Templates by lazy {
+            factory.newTemplates(
+                StreamSource(StringReader(redactTokenXslt))
+            )
+        }
+
+        fun redactToken(input: String): String {
+            val source = StreamSource(StringReader(input))
+            val writer = StringWriter()
+            val result = StreamResult(writer)
+            val transformer = tokenTemplates.newTransformer()
+            transformer.transform(source, result)
+            return writer.toString()
+        }
+
         private val redactXslt =
             """
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"

--- a/src/test/kotlin/org/jitsi/xmpp/util/RedactColibriTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/util/RedactColibriTest.kt
@@ -20,6 +20,7 @@ import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import org.jitsi.xmpp.util.RedactColibri.Companion.redactHttpHeaderValues
 import org.jitsi.xmpp.util.RedactColibri.Companion.redactIp
+import org.jitsi.xmpp.util.RedactColibri.Companion.redactToken
 import org.xmlunit.builder.DiffBuilder
 
 class RedactColibriTest : ShouldSpec() {
@@ -254,6 +255,34 @@ class RedactColibriTest : ShouldSpec() {
             val redacted = redactHttpHeaderValues(sourceXml)
 
             should("Redact all http-header values") {
+                val diff = DiffBuilder.compare(expectedXml).withTest(redacted)
+                    .ignoreWhitespace()
+                    .checkForIdentical().build()
+
+                diff.asClue {
+                    diff.hasDifferences() shouldBe false
+                }
+            }
+        }
+
+        context("Redacting a ConferenceIq token") {
+            val sourceXml =
+                """
+<iq xmlns="jabber:client" to="focus@auth.example.com" from="user@example.com/abc" id="id1" type="set">
+  <conference xmlns="http://jitsi.org/protocol/focus" room="room1@conference.example.com" token="eyJhbGciOiJIUzI1NiJ9.super-secret-jwt"/>
+</iq>
+                """
+
+            val expectedXml =
+                """
+<iq xmlns="jabber:client" to="focus@auth.example.com" from="user@example.com/abc" id="id1" type="set">
+  <conference xmlns="http://jitsi.org/protocol/focus" room="room1@conference.example.com" token="[redacted]"/>
+</iq>
+                """
+
+            val redacted = redactToken(sourceXml)
+
+            should("Redact the token attribute") {
                 val diff = DiffBuilder.compare(expectedXml).withTest(redacted)
                     .ignoreWhitespace()
                     .checkForIdentical().build()


### PR DESCRIPTION
## Summary
- Add `redactToken()` to `RedactColibri`, following the same XSLT-based pattern as `redactIp()`/`redactHttpHeaderValues()`
- Redacts the `token` attribute of `ConferenceIq` (the JWT auth token) so it can be scrubbed from XML before logging
