### PR TITLE
feat: Add a client-version extension for jingle.

### DIFF
--- a/src/main/kotlin/org/jitsi/xmpp/extensions/jitsimeet/ClientVersionPacketExtension.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/jitsimeet/ClientVersionPacketExtension.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright @ 2026 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.xmpp.extensions.jitsimeet
+
+import org.jitsi.xmpp.extensions.AbstractPacketExtension
+import org.jitsi.xmpp.extensions.DefaultPacketExtensionProvider
+import org.jivesoftware.smack.provider.ProviderManager
+
+/**
+ * The version of a client, which the client includes in the Jingle session-accept that it sends to the focus. The
+ * focus uses it for logging, for example when a client does not advertise a capability that the deployment requires.
+ */
+class ClientVersionPacketExtension() : AbstractPacketExtension(NAMESPACE, ELEMENT) {
+    constructor(version: String) : this() {
+        setAttribute(VERSION_ATTR_NAME, version)
+    }
+
+    val version: String?
+        get() = getAttributeAsString(VERSION_ATTR_NAME)
+
+    companion object {
+        const val ELEMENT = "client-version"
+
+        /** The namespace used for the signaling between a client and the focus. */
+        const val NAMESPACE = ConferenceIq.NAMESPACE
+
+        const val VERSION_ATTR_NAME = "version"
+
+        fun registerProvider() {
+            ProviderManager.addExtensionProvider(
+                ELEMENT,
+                NAMESPACE,
+                DefaultPacketExtensionProvider(ClientVersionPacketExtension::class.java)
+            )
+        }
+    }
+}

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/jitsimeet/ClientVersionPacketExtensionTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/jitsimeet/ClientVersionPacketExtensionTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright @ 2026 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.xmpp.extensions.jitsimeet
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.jitsi.xmpp.extensions.jingle.JingleIQ
+import org.jitsi.xmpp.extensions.jingle.JingleIQProvider
+import org.jivesoftware.smack.provider.ProviderManager
+import org.jivesoftware.smack.util.PacketParserUtils
+
+class ClientVersionPacketExtensionTest : ShouldSpec() {
+    init {
+        ClientVersionPacketExtension.registerProvider()
+        ProviderManager.addIQProvider(JingleIQ.ELEMENT, JingleIQ.NAMESPACE, JingleIQProvider())
+
+        context("Serializing") {
+            val extension = ClientVersionPacketExtension("abc1234")
+
+            extension.version shouldBe "abc1234"
+            extension.toXML().toString() shouldBe
+                "<client-version xmlns='http://jitsi.org/protocol/focus' version='abc1234'/>"
+        }
+
+        context("Parsing a session-accept which carries the extension") {
+            // Whitespace matters, the jingle provider does not expect character data between the elements.
+            val iq = PacketParserUtils.parseStanza<JingleIQ>(
+                "<iq from='room@conference.example.com/abcdabcd' to='focus@auth.example.com' type='set' id='id'>" +
+                    "<jingle xmlns='urn:xmpp:jingle:1' action='session-accept' sid='sid'>" +
+                    "<client-version xmlns='http://jitsi.org/protocol/focus' version='abc1234'/>" +
+                    "</jingle>" +
+                    "</iq>"
+            )
+
+            iq.getExtension(ClientVersionPacketExtension::class.java).let {
+                it.shouldNotBeNull()
+                it.version shouldBe "abc1234"
+            }
+        }
+
+        context("Parsing a session-accept with no extension") {
+            val iq = PacketParserUtils.parseStanza<JingleIQ>(
+                "<iq from='room@conference.example.com/abcdabcd' to='focus@auth.example.com' type='set' id='id'>" +
+                    "<jingle xmlns='urn:xmpp:jingle:1' action='session-accept' sid='sid'/>" +
+                    "</iq>"
+            )
+
+            iq.getExtension(ClientVersionPacketExtension::class.java) shouldBe null
+        }
+    }
+}


### PR DESCRIPTION
Adds a `client-version` extension for jingle. A client includes it in the session-accept that it sends to the focus, and the focus uses it for logging, for example when a client does not advertise a capability that the deployment requires.

The extension goes only to the focus, so the version does not reach the other endpoints. It uses the same namespace as `bridge-session`, which is also used only between a client and the focus.

Used by:
- lib-jitsi-meet: https://github.com/jitsi/lib-jitsi-meet/pull/3091
- jicofo: https://github.com/jitsi/jicofo/pull/1303
