### PR TITLE
Update to Kotlin 2.4.20, JUnit 5.14.4, kotest 5.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M6</version>
+        <configuration>
+          <systemPropertyVariables>
+            <kotest.framework.classpath.scanning.autoscan.disable>true</kotest.framework.classpath.scanning.autoscan.disable>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,10 @@
     <!-- Make sure this matches the version of the jxmpp artifacts inherited from smack. -->
     <jxmpp.version>1.0.3</jxmpp.version>
     <smack.version>4.4.8-jitsi-4</smack.version>
-    <junit.version>5.10.0</junit.version>
-    <kotlin.version>1.9.10</kotlin.version>
-    <kotest.version>5.7.2</kotest.version>
+    <junit.version>5.14.4</junit.version>
+    <junit.platform.version>1.14.4</junit.platform.version>
+    <kotlin.version>2.4.20</kotlin.version>
+    <kotest.version>5.9.1</kotest.version>
   </properties>
   <name>jitsi-xmpp-extensions</name>
   <description>Smack extensions used in Jitsi projects</description>
@@ -104,6 +105,12 @@
     </dependency>
     <!-- test -->
     <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>${junit.platform.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>${junit.version}</version>
@@ -111,7 +118,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.jitsi</groupId>
       <artifactId>jitsi-utils</artifactId>
-      <version>1.0-150-g4ab9a3b</version>
+      <version>1.0-153-gd5c0102</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/test/java/org/jitsi/xmpp/extensions/colibri2/Colibri2IQTest.java
+++ b/src/test/java/org/jitsi/xmpp/extensions/colibri2/Colibri2IQTest.java
@@ -16,6 +16,7 @@
 package org.jitsi.xmpp.extensions.colibri2;
 
 import org.jitsi.utils.*;
+import org.jitsi.utils.MediaType;
 import org.jitsi.xmpp.extensions.colibri.*;
 import org.jitsi.xmpp.extensions.jingle.*;
 import org.jivesoftware.smack.packet.*;

--- a/src/test/java/org/jitsi/xmpp/extensions/colibri2/MediaSourceTest.java
+++ b/src/test/java/org/jitsi/xmpp/extensions/colibri2/MediaSourceTest.java
@@ -16,6 +16,7 @@
 package org.jitsi.xmpp.extensions.colibri2;
 
 import org.jitsi.utils.*;
+import org.jitsi.utils.MediaType;
 import org.jivesoftware.smack.util.*;
 import org.junit.jupiter.api.*;
 


### PR DESCRIPTION
Bumps Kotlin to 2.4.20 and the test tooling to current versions.

Declares the JUnit platform launcher explicitly so the platform version matches the Jupiter engine rather than the older one kotest pulls in. Imports org.jitsi.utils.MediaType explicitly in two tests, since JUnit 5.12 added org.junit.jupiter.api.MediaType and made the wildcard imports ambiguous. Disables kotest classpath autoscan; the set of tests run is unchanged.

This is one of a set of same-named `kotlin-2.4` branches across jitsi-utils, jitsi-metaconfig, jicoco, jitsi-xmpp-extensions, ice4j, jicofo, jitsi-videobridge and jibri. Each PR only bumps the compiler and test/doc tooling; dependency versions between the jitsi repos are unchanged, so the PRs are independently mergeable. A library built with Kotlin 2.4 can only be consumed by Kotlin 2.3 or newer, so the compiler bumps should land everywhere before any repo picks up a 2.4-built release of another.