### PR TITLE
Run ktlint 1.8.0 directly via exec-maven-plugin and reformat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,6 @@
 [*.{kt,kts}]    
+# Keep constructor parameters wrapped one per line, and kotest specs unindented.
+ktlint_standard_class-signature = disabled
 max_line_length = 120
 
 ktlint_code_style = intellij_idea

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <junit.platform.version>1.14.4</junit.platform.version>
     <kotlin.version>2.4.20</kotlin.version>
     <kotest.version>5.9.1</kotest.version>
+    <ktlint.version>1.8.0</ktlint.version>
   </properties>
   <name>jitsi-xmpp-extensions</name>
   <description>Smack extensions used in Jitsi projects</description>
@@ -191,24 +192,61 @@
           <jvmTarget>11</jvmTarget>
         </configuration>
       </plugin>
+      <!-- ktlint: check runs in the verify phase; auto-format with "mvn exec:exec@ktlint-format" -->
       <plugin>
-        <groupId>com.github.gantsign.maven</groupId>
-        <artifactId>ktlint-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <configuration>
-          <sourceRoots>
-            <sourceRoot>${project.basedir}/src/main/kotlin</sourceRoot>
-          </sourceRoots>
-          <testSourceRoots>
-            <testSourceRoot>${project.basedir}/src/test/kotlin</testSourceRoot>
-          </testSourceRoots>
-        </configuration>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.6.3</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.pinterest.ktlint</groupId>
+            <artifactId>ktlint-cli</artifactId>
+            <version>${ktlint.version}</version>
+            <classifier>all</classifier>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
-            <id>check</id>
+            <id>ktlint-check</id>
+            <phase>verify</phase>
             <goals>
-              <goal>check</goal>
+              <goal>exec</goal>
             </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>ktlint-format</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--format</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/Connect.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/Connect.kt
@@ -289,6 +289,7 @@ class ConnectProvider : DefaultPacketExtensionProvider<Connect>(Connect::class.j
                             val sanitizedValue = headerValue.replace("\r", "").replace("\n", "")
                             connect.addHttpHeader(headerName, sanitizedValue)
                         }
+
                         Connect.Ping.ELEMENT -> {
                             val intervalStr = parser.getAttributeValue("", Connect.Ping.INTERVAL_ATTR_NAME)
                                 ?: throw SmackParsingException.RequiredAttributeMissingException(
@@ -310,11 +311,13 @@ class ConnectProvider : DefaultPacketExtensionProvider<Connect>(Connect::class.j
                             }
                             connect.setPing(interval, timeout)
                         }
+
                         Connect.Exports.ELEMENT -> {
                             connect.setExports(
                                 parseSourceNames(parser, Connect.Exports.ELEMENT, Connect.Export.ELEMENT)
                             )
                         }
+
                         Connect.Requests.ELEMENT -> {
                             connect.setRequests(
                                 parseSourceNames(parser, Connect.Requests.ELEMENT, Connect.Request.ELEMENT)
@@ -322,11 +325,13 @@ class ConnectProvider : DefaultPacketExtensionProvider<Connect>(Connect::class.j
                         }
                     }
                 }
+
                 XmlPullParser.Event.END_ELEMENT -> {
                     if (parser.name == Connect.ELEMENT && parser.depth <= depth) {
                         done = true
                     }
                 }
+
                 else -> { /* ignore */ }
             }
         }
@@ -353,11 +358,13 @@ class ConnectProvider : DefaultPacketExtensionProvider<Connect>(Connect::class.j
                         names.add(name)
                     }
                 }
+
                 XmlPullParser.Event.END_ELEMENT -> {
                     if (parser.name == containerElement) {
                         done = true
                     }
                 }
+
                 else -> { /* ignore */ }
             }
         }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONDeserializer.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONDeserializer.kt
@@ -42,122 +42,110 @@ import java.lang.IllegalArgumentException
 import java.net.URI
 
 object Colibri2JSONDeserializer {
-    private fun deserializeMedia(media: ObjectNode): Media {
-        return Media.getBuilder().apply {
-            media[Media.TYPE_ATTR_NAME]?.let {
-                require(it.isTextual) { "Expected string for ${Media.TYPE_ATTR_NAME}, got ${it.nodeType}" }
-                setType(MediaType.parseString(it.asText()))
-            }
+    private fun deserializeMedia(media: ObjectNode): Media = Media.getBuilder().apply {
+        media[Media.TYPE_ATTR_NAME]?.let {
+            require(it.isTextual) { "Expected string for ${Media.TYPE_ATTR_NAME}, got ${it.nodeType}" }
+            setType(MediaType.parseString(it.asText()))
+        }
 
-            media[Colibri2JSONSerializer.PAYLOAD_TYPES]?.let { payloadTypes ->
-                require(payloadTypes is ArrayNode) { "Expected array for payloadTypes, got ${payloadTypes.nodeType}" }
-                JSONDeserializer.deserializePayloadTypes(payloadTypes).forEach { addPayloadType(it) }
-            }
+        media[Colibri2JSONSerializer.PAYLOAD_TYPES]?.let { payloadTypes ->
+            require(payloadTypes is ArrayNode) { "Expected array for payloadTypes, got ${payloadTypes.nodeType}" }
+            JSONDeserializer.deserializePayloadTypes(payloadTypes).forEach { addPayloadType(it) }
+        }
 
-            media[Colibri2JSONSerializer.RTP_HEADER_EXTS]?.let { rtpHdrExts ->
-                require(rtpHdrExts is ArrayNode) { "Expected array for rtpHdrExts, got ${rtpHdrExts.nodeType}" }
-                JSONDeserializer.deserializeHeaderExtensions(rtpHdrExts).forEach { addRtpHdrExt(it) }
-            }
+        media[Colibri2JSONSerializer.RTP_HEADER_EXTS]?.let { rtpHdrExts ->
+            require(rtpHdrExts is ArrayNode) { "Expected array for rtpHdrExts, got ${rtpHdrExts.nodeType}" }
+            JSONDeserializer.deserializeHeaderExtensions(rtpHdrExts).forEach { addRtpHdrExt(it) }
+        }
 
-            media[ExtmapAllowMixedPacketExtension.ELEMENT]?.let {
-                require(it.isBoolean) {
-                    "Expected boolean for ${ExtmapAllowMixedPacketExtension.ELEMENT}, got ${it.nodeType}"
-                }
-                setExtmapAllowMixed(ExtmapAllowMixedPacketExtension())
+        media[ExtmapAllowMixedPacketExtension.ELEMENT]?.let {
+            require(it.isBoolean) {
+                "Expected boolean for ${ExtmapAllowMixedPacketExtension.ELEMENT}, got ${it.nodeType}"
             }
-        }.build()
-    }
+            setExtmapAllowMixed(ExtmapAllowMixedPacketExtension())
+        }
+    }.build()
 
-    private fun deserializeSctp(sctp: ObjectNode): Sctp {
-        return Sctp.Builder().apply {
-            sctp[Sctp.ROLE_ATTR_NAME]?.let {
-                require(it.isTextual) { "Expected string for ${Sctp.ROLE_ATTR_NAME}, got ${it.nodeType}" }
-                setRole(Sctp.Role.parseString(it.asText()))
-            }
+    private fun deserializeSctp(sctp: ObjectNode): Sctp = Sctp.Builder().apply {
+        sctp[Sctp.ROLE_ATTR_NAME]?.let {
+            require(it.isTextual) { "Expected string for ${Sctp.ROLE_ATTR_NAME}, got ${it.nodeType}" }
+            setRole(Sctp.Role.parseString(it.asText()))
+        }
 
-            sctp[Sctp.PORT_ATTR_NAME]?.let {
-                require(it.isNumber) { "Expected number for ${Sctp.PORT_ATTR_NAME}, got ${it.nodeType}" }
-                setPort(it.asInt())
-            }
-        }.build()
-    }
+        sctp[Sctp.PORT_ATTR_NAME]?.let {
+            require(it.isNumber) { "Expected number for ${Sctp.PORT_ATTR_NAME}, got ${it.nodeType}" }
+            setPort(it.asInt())
+        }
+    }.build()
 
-    private fun deserializeTransport(transport: ObjectNode): Transport {
-        return Transport.getBuilder().apply {
-            transport[Transport.ICE_CONTROLLING_ATTR_NAME]?.let {
-                require(it.isBoolean) {
-                    "Expected boolean for ${Transport.ICE_CONTROLLING_ATTR_NAME}, got ${it.nodeType}"
-                }
-                setIceControlling(it.asBoolean())
+    private fun deserializeTransport(transport: ObjectNode): Transport = Transport.getBuilder().apply {
+        transport[Transport.ICE_CONTROLLING_ATTR_NAME]?.let {
+            require(it.isBoolean) {
+                "Expected boolean for ${Transport.ICE_CONTROLLING_ATTR_NAME}, got ${it.nodeType}"
             }
+            setIceControlling(it.asBoolean())
+        }
 
-            transport[Transport.USE_UNIQUE_PORT_ATTR_NAME]?.let {
-                require(it.isBoolean) {
-                    "Expected boolean for ${Transport.USE_UNIQUE_PORT_ATTR_NAME}, got ${it.nodeType}"
-                }
-                setUseUniquePort(it.asBoolean())
+        transport[Transport.USE_UNIQUE_PORT_ATTR_NAME]?.let {
+            require(it.isBoolean) {
+                "Expected boolean for ${Transport.USE_UNIQUE_PORT_ATTR_NAME}, got ${it.nodeType}"
             }
+            setUseUniquePort(it.asBoolean())
+        }
 
-            transport[IceUdpTransportPacketExtension.ELEMENT]?.let {
-                require(it is ObjectNode) {
-                    "Expected object for ${IceUdpTransportPacketExtension.ELEMENT}, got ${it.nodeType}"
-                }
-                setIceUdpExtension(JSONDeserializer.deserializeTransport(it))
+        transport[IceUdpTransportPacketExtension.ELEMENT]?.let {
+            require(it is ObjectNode) {
+                "Expected object for ${IceUdpTransportPacketExtension.ELEMENT}, got ${it.nodeType}"
             }
+            setIceUdpExtension(JSONDeserializer.deserializeTransport(it))
+        }
 
-            transport[Sctp.ELEMENT]?.let {
-                require(it is ObjectNode) { "Expected object for ${Sctp.ELEMENT}, got ${it.nodeType}" }
-                setSctp(deserializeSctp(it))
-            }
-        }.build()
-    }
+        transport[Sctp.ELEMENT]?.let {
+            require(it is ObjectNode) { "Expected object for ${Sctp.ELEMENT}, got ${it.nodeType}" }
+            setSctp(deserializeSctp(it))
+        }
+    }.build()
 
-    private fun deserializeMediaSource(mediaSource: ObjectNode): MediaSource {
-        return MediaSource.getBuilder().apply {
-            mediaSource[MediaSource.TYPE_ATTR_NAME]?.let {
-                require(it.isTextual) { "Expected string for ${MediaSource.TYPE_ATTR_NAME}, got ${it.nodeType}" }
-                setType(MediaType.parseString(it.asText()))
-            }
+    private fun deserializeMediaSource(mediaSource: ObjectNode): MediaSource = MediaSource.getBuilder().apply {
+        mediaSource[MediaSource.TYPE_ATTR_NAME]?.let {
+            require(it.isTextual) { "Expected string for ${MediaSource.TYPE_ATTR_NAME}, got ${it.nodeType}" }
+            setType(MediaType.parseString(it.asText()))
+        }
 
-            mediaSource[MediaSource.ID_NAME]?.let {
-                require(it.isTextual) { "Expected string for ${MediaSource.ID_NAME}, got ${it.nodeType}" }
-                setId(it.asText())
-            }
+        mediaSource[MediaSource.ID_NAME]?.let {
+            require(it.isTextual) { "Expected string for ${MediaSource.ID_NAME}, got ${it.nodeType}" }
+            setId(it.asText())
+        }
 
-            mediaSource[MediaSource.SYNTHETIC_ATTR_NAME]?.let {
-                require(it.isBoolean) { "Expected boolean for ${MediaSource.SYNTHETIC_ATTR_NAME}, got ${it.nodeType}" }
-                setSynthetic(it.asBoolean())
-            }
+        mediaSource[MediaSource.SYNTHETIC_ATTR_NAME]?.let {
+            require(it.isBoolean) { "Expected boolean for ${MediaSource.SYNTHETIC_ATTR_NAME}, got ${it.nodeType}" }
+            setSynthetic(it.asBoolean())
+        }
 
-            mediaSource[Colibri2JSONSerializer.SOURCES]?.let { sources ->
-                require(sources is ArrayNode) { "Expected array for sources, got ${sources.nodeType}" }
-                sources.forEach { addSource(JSONDeserializer.deserializeSource(it)) }
-            }
+        mediaSource[Colibri2JSONSerializer.SOURCES]?.let { sources ->
+            require(sources is ArrayNode) { "Expected array for sources, got ${sources.nodeType}" }
+            sources.forEach { addSource(JSONDeserializer.deserializeSource(it)) }
+        }
 
-            mediaSource[Colibri2JSONSerializer.SOURCE_GROUPS]?.let { sourceGroups ->
-                require(sourceGroups is ArrayNode) { "Expected array for sourceGroups, got ${sourceGroups.nodeType}" }
-                sourceGroups.forEach { addSsrcGroup(JSONDeserializer.deserializeSourceGroup(it)) }
-            }
-        }.build()
-    }
+        mediaSource[Colibri2JSONSerializer.SOURCE_GROUPS]?.let { sourceGroups ->
+            require(sourceGroups is ArrayNode) { "Expected array for sourceGroups, got ${sourceGroups.nodeType}" }
+            sourceGroups.forEach { addSsrcGroup(JSONDeserializer.deserializeSourceGroup(it)) }
+        }
+    }.build()
 
-    private fun deserializeMedias(medias: ArrayNode): Collection<Media> {
-        return ArrayList<Media>().apply {
-            medias.forEach {
-                require(it is ObjectNode) { "Expected object for media element, got ${it.nodeType}" }
-                add(deserializeMedia(it))
-            }
+    private fun deserializeMedias(medias: ArrayNode): Collection<Media> = ArrayList<Media>().apply {
+        medias.forEach {
+            require(it is ObjectNode) { "Expected object for media element, got ${it.nodeType}" }
+            add(deserializeMedia(it))
         }
     }
 
-    private fun deserializeSources(sources: ArrayNode): Sources {
-        return Sources.getBuilder().apply {
-            sources.forEach {
-                require(it is ObjectNode) { "Expected object for source element, got ${it.nodeType}" }
-                addMediaSource(deserializeMediaSource(it))
-            }
-        }.build()
-    }
+    private fun deserializeSources(sources: ArrayNode): Sources = Sources.getBuilder().apply {
+        sources.forEach {
+            require(it is ObjectNode) { "Expected object for source element, got ${it.nodeType}" }
+            addMediaSource(deserializeMediaSource(it))
+        }
+    }.build()
 
     private fun deserializeAbstractConferenceEntityToBuilder(
         entity: ObjectNode,
@@ -220,81 +208,74 @@ object Colibri2JSONDeserializer {
         )
     }
 
-    private fun deserializeEndpoint(endpoint: ObjectNode): Colibri2Endpoint {
-        return Colibri2Endpoint.getBuilder().apply {
-            deserializeAbstractConferenceEntityToBuilder(endpoint, this)
+    private fun deserializeEndpoint(endpoint: ObjectNode): Colibri2Endpoint = Colibri2Endpoint.getBuilder().apply {
+        deserializeAbstractConferenceEntityToBuilder(endpoint, this)
 
-            endpoint[Colibri2Endpoint.STATS_ID_ATTR_NAME]?.let {
-                require(it.isTextual) {
-                    "Expected string for ${Colibri2Endpoint.STATS_ID_ATTR_NAME}, got ${it.nodeType}"
-                }
-                setStatsId(it.asText())
+        endpoint[Colibri2Endpoint.STATS_ID_ATTR_NAME]?.let {
+            require(it.isTextual) {
+                "Expected string for ${Colibri2Endpoint.STATS_ID_ATTR_NAME}, got ${it.nodeType}"
             }
+            setStatsId(it.asText())
+        }
 
-            endpoint[Colibri2Endpoint.MUC_ROLE_ATTR_NAME]?.let {
-                require(it.isTextual) {
-                    "Expected string for ${Colibri2Endpoint.MUC_ROLE_ATTR_NAME}, got ${it.nodeType}"
-                }
-                setMucRole(MUCRole.fromString(it.asText()))
+        endpoint[Colibri2Endpoint.MUC_ROLE_ATTR_NAME]?.let {
+            require(it.isTextual) {
+                "Expected string for ${Colibri2Endpoint.MUC_ROLE_ATTR_NAME}, got ${it.nodeType}"
             }
+            setMucRole(MUCRole.fromString(it.asText()))
+        }
 
-            endpoint[ForceMute.ELEMENT]?.let {
-                require(it is ObjectNode) { "Expected object for ${ForceMute.ELEMENT}, got ${it.nodeType}" }
-                setForceMute(deserializeForceMute(it))
+        endpoint[ForceMute.ELEMENT]?.let {
+            require(it is ObjectNode) { "Expected object for ${ForceMute.ELEMENT}, got ${it.nodeType}" }
+            setForceMute(deserializeForceMute(it))
+        }
+
+        endpoint[InitialLastN.ELEMENT]?.let {
+            require(it is ObjectNode) { "Expected object for ${InitialLastN.ELEMENT}, got ${it.nodeType}" }
+            setInitialLastN(deserializeInitialLastN(it))
+        }
+
+        endpoint[Colibri2JSONSerializer.CAPABILITIES_LIST]?.let { capabilities ->
+            require(capabilities is ArrayNode) {
+                "Expected array for capabilitiesList, got ${capabilities.nodeType}"
             }
-
-            endpoint[InitialLastN.ELEMENT]?.let {
-                require(it is ObjectNode) { "Expected object for ${InitialLastN.ELEMENT}, got ${it.nodeType}" }
-                setInitialLastN(deserializeInitialLastN(it))
+            capabilities.forEach {
+                require(it.isTextual) { "Expected string capability, got ${it.nodeType}" }
+                addCapability(it.asText())
             }
+        }
+    }.build()
 
-            endpoint[Colibri2JSONSerializer.CAPABILITIES_LIST]?.let { capabilities ->
-                require(capabilities is ArrayNode) {
-                    "Expected array for capabilitiesList, got ${capabilities.nodeType}"
-                }
-                capabilities.forEach {
-                    require(it.isTextual) { "Expected string capability, got ${it.nodeType}" }
-                    addCapability(it.asText())
-                }
-            }
-        }.build()
-    }
+    private fun deserializeRelay(relay: ObjectNode): Colibri2Relay = Colibri2Relay.getBuilder().apply {
+        deserializeAbstractConferenceEntityToBuilder(relay, this)
 
-    private fun deserializeRelay(relay: ObjectNode): Colibri2Relay {
-        return Colibri2Relay.getBuilder().apply {
-            deserializeAbstractConferenceEntityToBuilder(relay, this)
+        relay[Colibri2Relay.MESH_ID_ATTR_NAME]?.let {
+            require(it.isTextual) { "Expected string for ${Colibri2Relay.MESH_ID_ATTR_NAME}, got ${it.nodeType}" }
+            setMeshId(it.asText())
+        }
 
-            relay[Colibri2Relay.MESH_ID_ATTR_NAME]?.let {
-                require(it.isTextual) { "Expected string for ${Colibri2Relay.MESH_ID_ATTR_NAME}, got ${it.nodeType}" }
-                setMeshId(it.asText())
-            }
+        relay[Colibri2JSONSerializer.ENDPOINTS]?.let { endpoints ->
+            require(endpoints is ArrayNode) { "Expected array for endpoints, got ${endpoints.nodeType}" }
+            setEndpoints(
+                Endpoints.getBuilder().apply {
+                    deserializeEndpoints(endpoints).forEach { addEndpoint(it) }
+                }.build()
+            )
+        }
+    }.build()
 
-            relay[Colibri2JSONSerializer.ENDPOINTS]?.let { endpoints ->
-                require(endpoints is ArrayNode) { "Expected array for endpoints, got ${endpoints.nodeType}" }
-                setEndpoints(
-                    Endpoints.getBuilder().apply {
-                        deserializeEndpoints(endpoints).forEach { addEndpoint(it) }
-                    }.build()
-                )
-            }
-        }.build()
-    }
-
-    private fun deserializeEndpoints(endpoints: ArrayNode): Collection<Colibri2Endpoint> {
-        return ArrayList<Colibri2Endpoint>().apply {
+    private fun deserializeEndpoints(endpoints: ArrayNode): Collection<Colibri2Endpoint> =
+        ArrayList<Colibri2Endpoint>().apply {
             endpoints.forEach {
                 require(it is ObjectNode) { "Expected object for endpoint element, got ${it.nodeType}" }
                 add(deserializeEndpoint(it))
             }
         }
-    }
 
-    private fun deserializeRelays(relays: ArrayNode): Collection<Colibri2Relay> {
-        return ArrayList<Colibri2Relay>().apply {
-            relays.forEach {
-                require(it is ObjectNode) { "Expected object for relay element, got ${it.nodeType}" }
-                add(deserializeRelay(it))
-            }
+    private fun deserializeRelays(relays: ArrayNode): Collection<Colibri2Relay> = ArrayList<Colibri2Relay>().apply {
+        relays.forEach {
+            require(it is ObjectNode) { "Expected object for relay element, got ${it.nodeType}" }
+            add(deserializeRelay(it))
         }
     }
 
@@ -314,8 +295,8 @@ object Colibri2JSONDeserializer {
     }
 
     @JvmStatic
-    fun deserializeConferenceModify(conferenceModify: ObjectNode): ConferenceModifyIQ.Builder {
-        return ConferenceModifyIQ.builder("id").apply {
+    fun deserializeConferenceModify(conferenceModify: ObjectNode): ConferenceModifyIQ.Builder =
+        ConferenceModifyIQ.builder("id").apply {
             deserializeAbstractConferenceModificationToBuilder(conferenceModify, this)
 
             conferenceModify[ConferenceModifyIQ.MEETING_ID_ATTR_NAME]?.let {
@@ -437,16 +418,14 @@ object Colibri2JSONDeserializer {
                 if (!added) setEmptyConnects()
             }
         }
-    }
 
     @JvmStatic
-    fun deserializeConferenceModified(conferenceModified: ObjectNode): ConferenceModifiedIQ.Builder {
-        return ConferenceModifiedIQ.builder("id").apply {
+    fun deserializeConferenceModified(conferenceModified: ObjectNode): ConferenceModifiedIQ.Builder =
+        ConferenceModifiedIQ.builder("id").apply {
             deserializeAbstractConferenceModificationToBuilder(conferenceModified, this)
             conferenceModified[Sources.ELEMENT]?.let {
                 require(it is ArrayNode) { "Expected array for ${Sources.ELEMENT}, got ${it.nodeType}" }
                 setSources(deserializeSources(it))
             }
         }
-    }
 }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializer.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializer.kt
@@ -91,71 +91,59 @@ object Colibri2JSONSerializer {
      */
     const val SOURCES = SourcePacketExtension.ELEMENT + "s"
 
-    private fun serializeMedia(media: Media): ObjectNode {
-        return JsonNodeFactory.instance.objectNode().apply {
-            put(Media.TYPE_ATTR_NAME, media.type.toString())
-            if (media.payloadTypes.isNotEmpty()) {
-                set<ObjectNode>(PAYLOAD_TYPES, JSONSerializer.serializePayloadTypes(media.payloadTypes))
-            }
-            if (media.rtpHdrExts.isNotEmpty()) {
-                set<ObjectNode>(RTP_HEADER_EXTS, JSONSerializer.serializeRtpHdrExts(media.rtpHdrExts))
-            }
-            media.extmapAllowMixed?.let { put(ExtmapAllowMixedPacketExtension.ELEMENT, true) }
+    private fun serializeMedia(media: Media): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
+        put(Media.TYPE_ATTR_NAME, media.type.toString())
+        if (media.payloadTypes.isNotEmpty()) {
+            set<ObjectNode>(PAYLOAD_TYPES, JSONSerializer.serializePayloadTypes(media.payloadTypes))
+        }
+        if (media.rtpHdrExts.isNotEmpty()) {
+            set<ObjectNode>(RTP_HEADER_EXTS, JSONSerializer.serializeRtpHdrExts(media.rtpHdrExts))
+        }
+        media.extmapAllowMixed?.let { put(ExtmapAllowMixedPacketExtension.ELEMENT, true) }
+    }
+
+    private fun serializeSctp(sctp: Sctp): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
+        sctp.port?.let { put(Sctp.PORT_ATTR_NAME, it) }
+        sctp.role?.let { put(Sctp.ROLE_ATTR_NAME, it.toString()) }
+    }
+
+    private fun serializeTransport(transport: Transport): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
+        if (transport.iceControlling != Transport.ICE_CONTROLLING_DEFAULT) {
+            put(Transport.ICE_CONTROLLING_ATTR_NAME, transport.iceControlling)
+        }
+        if (transport.useUniquePort != Transport.USE_UNIQUE_PORT_DEFAULT) {
+            put(Transport.USE_UNIQUE_PORT_ATTR_NAME, transport.useUniquePort)
+        }
+        transport.iceUdpTransport?.let {
+            set<ObjectNode>(IceUdpTransportPacketExtension.ELEMENT, JSONSerializer.serializeTransport(it))
+        }
+        transport.sctp?.let {
+            set<ObjectNode>(Sctp.ELEMENT, serializeSctp(it))
         }
     }
 
-    private fun serializeSctp(sctp: Sctp): ObjectNode {
-        return JsonNodeFactory.instance.objectNode().apply {
-            sctp.port?.let { put(Sctp.PORT_ATTR_NAME, it) }
-            sctp.role?.let { put(Sctp.ROLE_ATTR_NAME, it.toString()) }
+    private fun serializeMediaSource(source: MediaSource): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
+        put(MediaSource.TYPE_ATTR_NAME, source.type.toString())
+        put(MediaSource.ID_NAME, source.id)
+        if (source.isSynthetic) put(MediaSource.SYNTHETIC_ATTR_NAME, true)
+        if (source.sources.isNotEmpty()) {
+            set<ObjectNode>(SOURCES, JSONSerializer.serializeSources(source.sources))
+        }
+        if (source.ssrcGroups.isNotEmpty()) {
+            set<ObjectNode>(SOURCE_GROUPS, JSONSerializer.serializeSourceGroups(source.ssrcGroups))
         }
     }
 
-    private fun serializeTransport(transport: Transport): ObjectNode {
-        return JsonNodeFactory.instance.objectNode().apply {
-            if (transport.iceControlling != Transport.ICE_CONTROLLING_DEFAULT) {
-                put(Transport.ICE_CONTROLLING_ATTR_NAME, transport.iceControlling)
-            }
-            if (transport.useUniquePort != Transport.USE_UNIQUE_PORT_DEFAULT) {
-                put(Transport.USE_UNIQUE_PORT_ATTR_NAME, transport.useUniquePort)
-            }
-            transport.iceUdpTransport?.let {
-                set<ObjectNode>(IceUdpTransportPacketExtension.ELEMENT, JSONSerializer.serializeTransport(it))
-            }
-            transport.sctp?.let {
-                set<ObjectNode>(Sctp.ELEMENT, serializeSctp(it))
-            }
-        }
+    private fun serializeMedias(medias: Collection<Media>): ArrayNode = JsonNodeFactory.instance.arrayNode().apply {
+        medias.forEach { add(serializeMedia(it)) }
     }
 
-    private fun serializeMediaSource(source: MediaSource): ObjectNode {
-        return JsonNodeFactory.instance.objectNode().apply {
-            put(MediaSource.TYPE_ATTR_NAME, source.type.toString())
-            put(MediaSource.ID_NAME, source.id)
-            if (source.isSynthetic) put(MediaSource.SYNTHETIC_ATTR_NAME, true)
-            if (source.sources.isNotEmpty()) {
-                set<ObjectNode>(SOURCES, JSONSerializer.serializeSources(source.sources))
-            }
-            if (source.ssrcGroups.isNotEmpty()) {
-                set<ObjectNode>(SOURCE_GROUPS, JSONSerializer.serializeSourceGroups(source.ssrcGroups))
-            }
-        }
+    private fun serializeSources(sources: Sources): ArrayNode = JsonNodeFactory.instance.arrayNode().apply {
+        sources.mediaSources.forEach { add(serializeMediaSource(it)) }
     }
 
-    private fun serializeMedias(medias: Collection<Media>): ArrayNode {
-        return JsonNodeFactory.instance.arrayNode().apply {
-            medias.forEach { add(serializeMedia(it)) }
-        }
-    }
-
-    private fun serializeSources(sources: Sources): ArrayNode {
-        return JsonNodeFactory.instance.arrayNode().apply {
-            sources.mediaSources.forEach { add(serializeMediaSource(it)) }
-        }
-    }
-
-    private fun serializeAbstractConferenceEntity(entity: AbstractConferenceEntity): ObjectNode {
-        return JsonNodeFactory.instance.objectNode().apply {
+    private fun serializeAbstractConferenceEntity(entity: AbstractConferenceEntity): ObjectNode =
+        JsonNodeFactory.instance.objectNode().apply {
             put(AbstractConferenceEntity.ID_ATTR_NAME, entity.id)
 
             if (entity.create != AbstractConferenceEntity.CREATE_DEFAULT) {
@@ -174,27 +162,23 @@ object Colibri2JSONSerializer {
 
             entity.sources?.let { set<ObjectNode>(Sources.ELEMENT, serializeSources(it)) }
         }
-    }
 
-    private fun serializeForceMute(forceMute: ForceMute): ObjectNode {
-        return JsonNodeFactory.instance.objectNode().apply {
-            put(ForceMute.AUDIO_ATTR_NAME, forceMute.audio)
-            put(ForceMute.VIDEO_ATTR_NAME, forceMute.video)
-        }
+    private fun serializeForceMute(forceMute: ForceMute): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
+        put(ForceMute.AUDIO_ATTR_NAME, forceMute.audio)
+        put(ForceMute.VIDEO_ATTR_NAME, forceMute.video)
     }
 
     private fun serializeInitialLastN(initialLastN: InitialLastN) = JsonNodeFactory.instance.objectNode().apply {
         put(InitialLastN.VALUE_ATTR_NAME, initialLastN.value)
     }
 
-    private fun serializeCapabilities(capabilities: Collection<Capability>): ArrayNode {
-        return JsonNodeFactory.instance.arrayNode().apply {
+    private fun serializeCapabilities(capabilities: Collection<Capability>): ArrayNode =
+        JsonNodeFactory.instance.arrayNode().apply {
             capabilities.forEach { add(it.name) }
         }
-    }
 
-    private fun serializeEndpoint(endpoint: Colibri2Endpoint): ObjectNode {
-        return serializeAbstractConferenceEntity(endpoint).apply {
+    private fun serializeEndpoint(endpoint: Colibri2Endpoint): ObjectNode =
+        serializeAbstractConferenceEntity(endpoint).apply {
             endpoint.statsId?.apply { put(Colibri2Endpoint.STATS_ID_ATTR_NAME, this) }
             endpoint.mucRole?.apply { put(Colibri2Endpoint.MUC_ROLE_ATTR_NAME, this.toString()) }
             endpoint.forceMute?.apply { set<ObjectNode>(ForceMute.ELEMENT, serializeForceMute(this)) }
@@ -203,29 +187,24 @@ object Colibri2JSONSerializer {
                 set<ObjectNode>(CAPABILITIES_LIST, serializeCapabilities(endpoint.capabilities))
             }
         }
+
+    private fun serializeRelay(relay: Colibri2Relay): ObjectNode = serializeAbstractConferenceEntity(relay).apply {
+        relay.meshId?.apply { put(Colibri2Relay.MESH_ID_ATTR_NAME, this) }
+        relay.endpoints?.let { set<ObjectNode>(ENDPOINTS, serializeEndpoints(it.endpoints)) }
     }
 
-    private fun serializeRelay(relay: Colibri2Relay): ObjectNode {
-        return serializeAbstractConferenceEntity(relay).apply {
-            relay.meshId?.apply { put(Colibri2Relay.MESH_ID_ATTR_NAME, this) }
-            relay.endpoints?.let { set<ObjectNode>(ENDPOINTS, serializeEndpoints(it.endpoints)) }
-        }
-    }
-
-    private fun serializeEndpoints(endpoints: Collection<Colibri2Endpoint>): ArrayNode {
-        return JsonNodeFactory.instance.arrayNode().apply {
+    private fun serializeEndpoints(endpoints: Collection<Colibri2Endpoint>): ArrayNode =
+        JsonNodeFactory.instance.arrayNode().apply {
             endpoints.forEach { add(serializeEndpoint(it)) }
         }
-    }
 
-    private fun serializeRelays(relays: Collection<Colibri2Relay>): ArrayNode {
-        return JsonNodeFactory.instance.arrayNode().apply {
+    private fun serializeRelays(relays: Collection<Colibri2Relay>): ArrayNode =
+        JsonNodeFactory.instance.arrayNode().apply {
             relays.forEach { add(serializeRelay(it)) }
         }
-    }
 
-    private fun serializeAbstractConferenceModificationIQ(iq: AbstractConferenceModificationIQ<*>): ObjectNode {
-        return JsonNodeFactory.instance.objectNode().apply {
+    private fun serializeAbstractConferenceModificationIQ(iq: AbstractConferenceModificationIQ<*>): ObjectNode =
+        JsonNodeFactory.instance.objectNode().apply {
             if (iq.endpoints.isNotEmpty()) {
                 set<ObjectNode>(ENDPOINTS, serializeEndpoints(iq.endpoints))
             }
@@ -233,7 +212,6 @@ object Colibri2JSONSerializer {
                 set<ObjectNode>(RELAYS, serializeRelays(iq.relays))
             }
         }
-    }
 
     private fun serializeConnect(connect: Connect) = JsonNodeFactory.instance.objectNode().apply {
         put(Connect.ID_ATTR_NAME, connect.id)
@@ -285,8 +263,8 @@ object Colibri2JSONSerializer {
     }
 
     @JvmStatic
-    fun serializeConferenceModify(iq: ConferenceModifyIQ): ObjectNode {
-        return serializeAbstractConferenceModificationIQ(iq).apply {
+    fun serializeConferenceModify(iq: ConferenceModifyIQ): ObjectNode =
+        serializeAbstractConferenceModificationIQ(iq).apply {
             if (iq.create != ConferenceModifyIQ.CREATE_DEFAULT) {
                 put(ConferenceModifyIQ.CREATE_ATTR_NAME, iq.create)
             }
@@ -307,12 +285,10 @@ object Colibri2JSONSerializer {
 
             iq.conferenceName?.let { put(ConferenceModifyIQ.NAME_ATTR_NAME, it) }
         }
-    }
 
     @JvmStatic
-    fun serializeConferenceModified(iq: ConferenceModifiedIQ): ObjectNode {
-        return serializeAbstractConferenceModificationIQ(iq).apply {
+    fun serializeConferenceModified(iq: ConferenceModifiedIQ): ObjectNode =
+        serializeAbstractConferenceModificationIQ(iq).apply {
             iq.sources?.let { set<ObjectNode>(Sources.ELEMENT, serializeSources(it)) }
         }
-    }
 }

--- a/src/main/kotlin/org/jitsi/xmpp/extensions/visitors/VisitorsIq.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/extensions/visitors/VisitorsIq.kt
@@ -80,9 +80,7 @@ class VisitorsIq private constructor(b: Builder) : IQ(b, ELEMENT, NAMESPACE) {
 
         var room: EntityBareJid? = null
 
-        override fun build(): VisitorsIq {
-            return VisitorsIq(this)
-        }
+        override fun build(): VisitorsIq = VisitorsIq(this)
 
         override fun getThis() = this
     }

--- a/src/main/kotlin/org/jitsi/xmpp/stringprep/JitsiXmppStringprep.kt
+++ b/src/main/kotlin/org/jitsi/xmpp/stringprep/JitsiXmppStringprep.kt
@@ -102,14 +102,12 @@ class IDNWithUnderscoreProfile : PrecisProfile(false) {
         /**
          *  Return true if [this] is a code for an ASCII character that is not a Letter/Digit/Hyphen/Underscore/Percent.
          */
-        private fun Int.isNonLDHUPAsciiCodePoint(): Boolean {
-            return (this in 0x0000..0x0024) ||
-                (this in 0x0026..0x002C) ||
-                (this == 0x002F) ||
-                (this in 0x003A..0x0040) ||
-                (this in 0x005B..0x005e) ||
-                (this == 0x0060) ||
-                (this in 0x007B..0x007F)
-        }
+        private fun Int.isNonLDHUPAsciiCodePoint(): Boolean = (this in 0x0000..0x0024) ||
+            (this in 0x0026..0x002C) ||
+            (this == 0x002F) ||
+            (this in 0x003A..0x0040) ||
+            (this in 0x005B..0x005e) ||
+            (this == 0x0060) ||
+            (this in 0x007B..0x007F)
     }
 }

--- a/src/test/kotlin/org/jitsi/xmpp/JidTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/JidTest.kt
@@ -37,9 +37,7 @@ import org.jxmpp.stringprep.XmppStringprepException
  * https://github.com/igniterealtime/jxmpp/blob/master/jxmpp-strings-testframework/src/main/resources/xmpp-strings/jids/invalid/main
  */
 class JidTest : ShouldSpec() {
-    override fun isolationMode(): IsolationMode {
-        return IsolationMode.SingleInstance
-    }
+    override fun isolationMode(): IsolationMode = IsolationMode.SingleInstance
     override suspend fun beforeAny(testCase: TestCase) {
         super.beforeAny(testCase)
         Smack.initialize()

--- a/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializerTest.kt
+++ b/src/test/kotlin/org/jitsi/xmpp/extensions/colibri2/json/Colibri2JSONSerializerTest.kt
@@ -65,11 +65,13 @@ class Colibri2JSONSerializerTest : ShouldSpec() {
 
                 val builder = when (it.clazz) {
                     ConferenceModifyIQ::class -> Colibri2JSONDeserializer.deserializeConferenceModify(json)
+
                     ConferenceModifiedIQ::class -> {
                         Colibri2JSONDeserializer.deserializeConferenceModified(json).also { b ->
                             b.ofType(IQ.Type.result)
                         }
                     }
+
                     else -> throw IllegalStateException("Bad type in test")
                 }
 


### PR DESCRIPTION
Replaces the third-party ktlint-maven-plugin, which tends to trail ktlint releases, with the integration ktlint documents itself: the ktlint CLI jar (1.8.0) as an exec-maven-plugin dependency, with the classpath restricted to that jar. The check still runs in the `verify` phase and fails the build on violations. Autoformat with `mvn exec:exec@ktlint-format` instead of `mvn ktlint:format`.

The `class-signature` rule added in ktlint 1.x is disabled in `.editorconfig`: it joins wrapped constructor parameter lists onto one line when they fit and re-indents every kotest spec, which we do not want. All other new rules are applied.

The second commit is the resulting reformat: 466 lines in 7 Kotlin files, almost entirely single-`return` function bodies becoming expression bodies and blank lines between multi-line `when` branches; plus KDoc comments that sat on non-declarations (ktlint cannot auto-correct these) become plain block comments. Behaviour-neutral.

This is one of a set of same-named `ktlint-1.8` branches across jitsi-utils, jitsi-metaconfig, jicoco, jitsi-xmpp-extensions, ice4j, jicofo, jitsi-videobridge and jibri. Each PR is independent; they only change how ktlint is run and apply its formatting.